### PR TITLE
Switch to dotnet/runtime main after PR #125005 merges

### DIFF
--- a/.github/workflows/generate-others.yml
+++ b/.github/workflows/generate-others.yml
@@ -20,8 +20,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Fetch from dotnet/runtime main (PR #125005 merged)
           gh api -H "Accept: application/vnd.github.raw" \
-            "repos/danmoseley/runtime/contents/.github/skills/pr-triage/scripts/Get-PrTriageData.ps1?ref=pr-triage-skill" \
+            "repos/dotnet/runtime/contents/.github/skills/pr-triage/scripts/Get-PrTriageData.ps1" \
             > Get-PrTriageData.ps1
 
       - name: Install gh-models extension

--- a/.github/workflows/generate-runtime.yml
+++ b/.github/workflows/generate-runtime.yml
@@ -20,9 +20,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Fetch from fork branch (change to dotnet/runtime main after PR #125005 merges)
+          # Fetch from dotnet/runtime main (PR #125005 merged)
           gh api -H "Accept: application/vnd.github.raw" \
-            "repos/danmoseley/runtime/contents/.github/skills/pr-triage/scripts/Get-PrTriageData.ps1?ref=pr-triage-skill" \
+            "repos/dotnet/runtime/contents/.github/skills/pr-triage/scripts/Get-PrTriageData.ps1" \
             > Get-PrTriageData.ps1
 
       - name: Install gh-models extension


### PR DESCRIPTION
Switch script fetch URL from `danmoseley/runtime@pr-triage-skill` to `dotnet/runtime` main.

**Merge this after [dotnet/runtime#125005](https://github.com/dotnet/runtime/pull/125005) lands.**
