### PR TITLE
Add CI validation for PRs

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -23,9 +23,8 @@ jobs:
         continue-on-error: true
         run: |
           CI_OUTPUT="${{ runner.temp }}/ci-output"
-          # Install headless Chrome dependencies
-          sudo apt-get update -qq && sudo apt-get install -y -qq chromium-browser > /dev/null 2>&1 || true
-          CHROME=$(which chromium-browser || which chromium || which google-chrome || echo "")
+          # Use pre-installed browser (ubuntu-latest includes google-chrome)
+          CHROME=$(which google-chrome || which chromium-browser || which chromium || echo "")
           if [ -z "$CHROME" ]; then
             echo "::notice::No browser found, skipping screenshots"
             exit 0
@@ -34,12 +33,12 @@ jobs:
           if [ -f "$CI_OUTPUT/index.html" ]; then
             "$CHROME" --headless --disable-gpu --no-sandbox --screenshot=screenshots/index.png --window-size=1400,900 "file://$CI_OUTPUT/index.html" 2>/dev/null || true
           fi
-          for slug in extensions machinelearning runtime; do
-            if [ -f "$CI_OUTPUT/${slug}/actionable.html" ]; then
-              "$CHROME" --headless --disable-gpu --no-sandbox --screenshot=screenshots/${slug}-actionable.png --window-size=1400,900 "file://$CI_OUTPUT/${slug}/actionable.html" 2>/dev/null || true
-              break
-            fi
-          done
+          # Find the first generated report dynamically
+          REPORT=$(find "$CI_OUTPUT" -name "actionable.html" -path "*/*/actionable.html" 2>/dev/null | head -1)
+          if [ -n "$REPORT" ]; then
+            SLUG=$(basename "$(dirname "$REPORT")")
+            "$CHROME" --headless --disable-gpu --no-sandbox --screenshot=screenshots/${SLUG}-actionable.png --window-size=1400,900 "file://$REPORT" 2>/dev/null || true
+          fi
           ls -la screenshots/ 2>/dev/null || echo "No screenshots produced"
 
       - name: Upload screenshots

--- a/scripts/Build-Reports.ps1
+++ b/scripts/Build-Reports.ps1
@@ -16,6 +16,9 @@
     Which reports to generate: top15, community, quick-wins. Default: all three.
 .PARAMETER SkipAI
     If set, skip AI observation generation.
+.PARAMETER SkipHistory
+    If set, skip fetching merged PR stats via GraphQL and updating history.json.
+    Use for offline/CI validation where API access is unavailable.
 #>
 [CmdletBinding()]
 param(

--- a/scripts/Test-CiValidation.ps1
+++ b/scripts/Test-CiValidation.ps1
@@ -6,7 +6,7 @@
       1. PowerShell syntax validation (all .ps1 files)
       2. JavaScript syntax validation (pr-refresh.js)
       3. JSON config validation (maintainers.json, repos.json)
-      4. HTML generation smoke test (Regen-Html on 2 small repos)
+      4. HTML generation smoke test (Build-Reports + Build-Index on 2 small repos)
       5. HTML structure validation (required elements exist)
       6. Output file completeness (expected files with correct schema)
     Exits non-zero if any critical check fails.


### PR DESCRIPTION
## Add CI validation for PRs

Adds a lightweight validation pipeline that catches regressions before merging — fully offline, no API calls.

### What it does

Runs **36 offline checks** across 6 categories on every PR to `main`:

1. **PowerShell syntax** — parses all `.ps1` files for syntax errors
2. **JavaScript syntax** — `node --check` on `pr-refresh.js` (gracefully skips if node unavailable)
3. **JSON config** — validates `maintainers.json` keys (GitHub slug format) and values (must be arrays), and `repos.json` structure
4. **HTML generation smoke test** — runs the full `Build-Reports` &#8594; `Build-Index` pipeline on 2 small repos from cached `scan.json` (~15s, truly offline via `-SkipHistory`)
5. **HTML structure** — verifies generated pages have required elements (tables, nav, data attributes, score/CI columns)
6. **Output completeness** — checks all expected files are produced and `meta.json` has the correct schema

Also captures headless browser **screenshots** of the freshly generated `index.html` and a report page, uploaded as workflow artifacts for visual review.

### Files

| File | Description |
|------|-------------|
| `.github/workflows/ci-validation.yml` | Workflow: triggers on PRs + `workflow_dispatch`, explicit `contents: read` permissions |
| `scripts/Test-CiValidation.ps1` | Validation script with all 36 checks, supports `-ArtifactDir` for persistent output |
| `scripts/Build-Reports.ps1` | Added `-SkipHistory` switch to skip GraphQL API calls for merged PR stats |
