### PR TITLE
Optimize report schedule: 1x weekends, skip redundant runs

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -24,7 +24,7 @@ jobs:
           # Skip this scheduled run if a manual run completed successfully in the last 10 hours
           # Non-fatal: if the API call fails, proceed with the run anyway
           cutoff=$(date -u -d '10 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
-          recent=$(gh api "repos/${{ github.repository }}/actions/workflows/generate-reports.yml/runs?branch=main&event=workflow_dispatch&status=completed&per_page=5" \
+          recent=$(gh api "repos/${{ github.repository }}/actions/workflows/generate-reports.yml/runs?branch=main&event=workflow_dispatch&status=completed&per_page=20" \
             --jq '[.workflow_runs[] | select(.conclusion == "success")][0].updated_at // empty' 2>/dev/null || true)
           if [ -n "$recent" ] && [[ "$recent" > "$cutoff" ]]; then
             echo "Skipping: recent manual run completed at $recent (cutoff: $cutoff)"
@@ -40,7 +40,7 @@ jobs:
         if: env.SKIP_RUN != 'true'
         run: |
           # Read schedule-desc from the workflow YAML comment (single source of truth)
-          desc=$(grep -oP '#\s*schedule-desc:\s*\K.+' .github/workflows/generate-reports.yml | head -1 || true)
+          desc=$(grep -oP '^\s*#\s*schedule-desc:\s*\K.+' .github/workflows/generate-reports.yml | head -1 || true)
           echo "SCHEDULE_DESC=${desc:-~twice daily (weekdays 2x, weekends 1x)}" >> "$GITHUB_ENV"
 
       - name: Install gh-models extension

--- a/scripts/Build-Index.ps1
+++ b/scripts/Build-Index.ps1
@@ -7,6 +7,9 @@
     Includes client-side JS for live "Xh ago" relative timestamps.
 .PARAMETER DocsDir
     Root docs directory (default: docs/).
+.PARAMETER ScheduleDesc
+    Human-readable schedule description (e.g., "~twice daily") displayed
+    alongside the relative timestamps in the generated index page.
 #>
 [CmdletBinding()]
 param(

--- a/scripts/Build-Reports.ps1
+++ b/scripts/Build-Reports.ps1
@@ -19,6 +19,9 @@
 .PARAMETER SkipHistory
     If set, skip fetching merged PR stats via GraphQL and updating history.json.
     Use for offline/CI validation where API access is unavailable.
+.PARAMETER ScheduleDesc
+    Human-readable schedule description (e.g., "~twice daily") displayed in
+    the report meta line. Passed through to ConvertTo-ReportHtml.
 #>
 [CmdletBinding()]
 param(

--- a/scripts/ConvertTo-ReportHtml.ps1
+++ b/scripts/ConvertTo-ReportHtml.ps1
@@ -18,6 +18,9 @@
     which enables client-side cache invalidation for per-PR refresh.
 .PARAMETER NavLinks
     Hashtable of name→filename for navigation links.
+.PARAMETER ScheduleDesc
+    Human-readable schedule description (e.g., "~twice daily") displayed in
+    the report meta line alongside the relative timestamp. Plain text, no HTML.
 #>
 [CmdletBinding()]
 param(

--- a/scripts/Regen-Html.ps1
+++ b/scripts/Regen-Html.ps1
@@ -22,8 +22,8 @@ $docsDir = Join-Path $root "docs"
 $workflowFile = Join-Path $root ".github/workflows/generate-reports.yml"
 $scheduleDesc = "~twice daily (weekdays 2x, weekends 1x)"  # fallback
 if (Test-Path $workflowFile) {
-    $descLine = Get-Content $workflowFile | Where-Object { $_ -match '#\s*schedule-desc:\s*(.+)' } | Select-Object -First 1
-    if ($descLine -and $descLine -match '#\s*schedule-desc:\s*(.+)') {
+    $descLine = Get-Content $workflowFile | Where-Object { $_ -match '^\s*#\s*schedule-desc:\s*(.+)' } | Select-Object -First 1
+    if ($descLine -and $descLine -match '^\s*#\s*schedule-desc:\s*(.+)') {
         $scheduleDesc = $Matches[1].Trim()
     }
 }

--- a/scripts/Test-CiValidation.ps1
+++ b/scripts/Test-CiValidation.ps1
@@ -144,8 +144,8 @@ if ($scanFiles.Count -eq 0) {
     $wfFile = Join-Path $root ".github/workflows/generate-reports.yml"
     $scheduleDesc = "~twice daily (weekdays 2x, weekends 1x)"  # fallback
     if (Test-Path $wfFile) {
-        $descLine = Get-Content $wfFile | Where-Object { $_ -match '#\s*schedule-desc:\s*(.+)' } | Select-Object -First 1
-        if ($descLine -and $descLine -match '#\s*schedule-desc:\s*(.+)') {
+        $descLine = Get-Content $wfFile | Where-Object { $_ -match '^\s*#\s*schedule-desc:\s*(.+)' } | Select-Object -First 1
+        if ($descLine -and $descLine -match '^\s*#\s*schedule-desc:\s*(.+)') {
             $scheduleDesc = $Matches[1].Trim()
         }
     }


### PR DESCRIPTION
## Optimize report generation schedule

Reduces Actions minutes usage by ~16% while maintaining fresh data for weekday mornings.

### Schedule changes
- **Weekdays:** 2x/day at 6am + 6pm UTC (~10pm/10am Pacific) -- unchanged frequency
- **Weekends:** 1x/day at 4pm UTC (~8am Pacific) -- down from 2x
- Monday 8am Pacific gets fresh data from the weekday 6am UTC run (~10pm Sunday Pacific)

### Skip redundant runs
- Scheduled runs now check for a successful run in the last 10 hours
- If one exists (e.g., from a manual `workflow_dispatch`), the scheduled run is skipped
- Manual triggers are never skipped

### Budget impact
| | Runs/month | Minutes/month | % of 2000 min quota |
|---|---|---|---|
| Before | ~60 | ~681 | 34% |
| After | ~52 | ~572 | 29% |
| **Saved** | **~8** | **~109** | **5%** |
