### PR TITLE
Fix column resizing: lock table layout before drag

### DIFF
--- a/docs/shared-ui.js
+++ b/docs/shared-ui.js
@@ -113,6 +113,9 @@
       if (locked) return; locked = true;
       // Freeze current column widths then switch to fixed layout
       var widths = Array.prototype.map.call(ths, function(h) { return h.offsetWidth + 'px'; });
+      // Clear <col> widths so th widths drive fixed-layout sizing
+      var cols = table.querySelectorAll('colgroup col');
+      cols.forEach(function(c) { c.style.width = ''; });
       ths.forEach(function(h, i) {
         h.style.width = widths[i]; h.style.minWidth = widths[i]; h.style.maxWidth = widths[i];
       });


### PR DESCRIPTION
Fix column resizing: lock table layout before drag

## Problem

Column resize handles appear (cursor changes to `col-resize`) but dragging does nothing. This regressed when shared-ui.js was extracted in #10.

## Root cause

`lockLayout()` set a `locked` flag but never actually changed the table's layout mode. With `table-layout: auto` (from shared-styles.css), the browser recalculates all column widths based on content after every change, so the explicit `width` set during drag was immediately overridden.

## Fix

On first mousedown, `lockLayout()` now:
1. Snapshots every column's current `offsetWidth`
2. Pins each as `width` / `minWidth` / `maxWidth`
3. Switches the table to `table-layout: fixed`

After that, manual width assignments during drag stick as expected.
