### PR TITLE
Compact Copilot reviewer display: bot icon instead of avatar+name

### DIFF
--- a/docs/shared-styles.css
+++ b/docs/shared-styles.css
@@ -98,7 +98,7 @@ th.sorted { color: var(--link); }
 }
 .filter-btn:hover { color: var(--link); border-color: var(--link); filter: none; }
 .avatar { width: 16px; height: 16px; border-radius: 50%; vertical-align: text-bottom; margin-right: 2px; }
-.bot-icon { font-size: 1.15em; vertical-align: text-bottom; }
+.bot-icon { font-size: 1.15em; vertical-align: text-bottom; display: inline-block; line-height: 1; }
 
 /* Scoring explainer */
 .scoring { margin: 0.5em 0 1em; max-width: 900px; color: var(--fg); font-size: 0.85em; }

--- a/scripts/ConvertTo-ReportHtml.ps1
+++ b/scripts/ConvertTo-ReportHtml.ps1
@@ -71,10 +71,10 @@ function ConvertTo-UserHtml([string]$text, [hashtable]$communitySet = @{}) {
             # Bot app — link to GitHub Apps page, no avatar/filter
             $name = $Matches[1]
             "<a href=`"https://github.com/apps/$name`">@$name</a>"
-        } elseif ($full -match 'copilot-pull-request-reviewer') {
+        } elseif ($full -eq 'copilot-pull-request-reviewer') {
             # Copilot reviewer — compact bot icon with filter
             $u = $full
-            "<span class=`"user-ref`"><span class=`"bot-icon`" title=`"Copilot reviewer`">&#x1F916;</span><a class=`"filter-btn`" href=`"#`" onclick=`"filterByUser('$u');return false`" title=`"Show only @$u`">&#x1F50D;</a></span>"
+            "<span class=`"user-ref`"><span class=`"bot-icon`" role=`"img`" aria-label=`"Copilot reviewer`" title=`"Copilot reviewer`">&#x1F916;</span><a class=`"filter-btn`" href=`"#`" onclick=`"filterByUser('$u');return false`" title=`"Show only @$u`">&#x1F50D;</a></span>"
         } else {
             $u = $full
             $cBadge = if ($communitySet.ContainsKey($u)) { '<span class="badge community" title="community">C</span>' } else { '' }
@@ -124,9 +124,9 @@ $rows = foreach ($pr in $prs) {
     $authorDisplay = ConvertTo-UserHtml "@$($pr.author)" $communityAuthors
     if ($pr.author -match "copilot-swe-agent") {
         if ($pr.copilot_trigger) {
-            $authorDisplay = "$(ConvertTo-UserHtml "@$($pr.copilot_trigger)" $communityAuthors) <span class=`"badge`" title=`"authored by Copilot`">via <span class=`"bot-icon`">&#x1F916;</span></span>"
+            $authorDisplay = "$(ConvertTo-UserHtml "@$($pr.copilot_trigger)" $communityAuthors) <span class=`"badge`" title=`"authored by Copilot`">via <span class=`"bot-icon`" role=`"img`" aria-label=`"Copilot`">&#x1F916;</span></span>"
         } else {
-            $authorDisplay = "<span class=`"bot-icon`">&#x1F916;</span> copilot"
+            $authorDisplay = "<span class=`"bot-icon`" role=`"img`" aria-label=`"Copilot`">&#x1F916;</span> copilot"
         }
     }
 


### PR DESCRIPTION
Compact Copilot reviewer display: bot icon instead of avatar+name

Replace the verbose `<avatar> @copilot-pull-request-reviewer` rendering with a compact bot icon. The filter button is retained so you can still filter by Copilot-reviewed PRs.

Also wraps the existing bot emoji in the Author column's "via" badge with the same `.bot-icon` class, making the icon slightly larger (1.15em) and consistently styled across both columns.

**Before:** avatar image + `@copilot-pull-request-reviewer` + filter
**After:** :robot: + filter
