### PR TITLE
Per-row refresh: 1 API call, stale score fading, rate limit footer

### DIFF
--- a/docs/pr-refresh.js
+++ b/docs/pr-refresh.js
@@ -89,7 +89,7 @@
       var btn = document.createElement('button');
       btn.className = 'pr-refresh-btn';
       btn.innerHTML = '&#x21bb;';
-      btn.title = 'Check current state; hides if merged/closed';
+      btn.title = 'Check current state; hides row if merged/closed';
       btn.setAttribute('aria-label', 'Check status of PR #' + info.number);
       btn.addEventListener('click', function(e) {
         e.preventDefault();

--- a/docs/shared-styles.css
+++ b/docs/shared-styles.css
@@ -142,7 +142,7 @@ a.feedback:hover { background: #388bfd; color: #fff; text-decoration: none; }
   a.feedback:hover { background: #0550ae; }
 }
 
-/* Stale scores — faded when row was refreshed (scores may be outdated) */
+/* Stale scores — faded when refresh detects a CI or conflict change */
 .scores-stale .score,
 .scores-stale .action-score { opacity: 0.6; }
 


### PR DESCRIPTION
## Per-row refresh: 1 API call, stale score fading, rate limit footer

Three improvements to the client-side per-PR refresh button in `pr-refresh.js`:

### 1. Halve API cost: 1 call per PR instead of 2

Previously, clicking ↻ on a PR row made 2 API calls:
1. `GET /pulls/{n}` — state, merged, mergeable_state
2. `GET /commits/{sha}/check-runs` — detailed CI pass/fail/pending counts

Now it makes **only the first call**. CI status is derived from `mergeable_state`:
- `clean` → ✅ (checks pass, no conflicts)
- `unstable` → ❌ (checks failing)
- `blocked` → ⏳ (pending checks or missing reviews)
- `dirty` → 🛑 conflict

This loses the detailed `137/5/0` counts but answers the key question (green or red?) and doubles the effective rate budget from 30 to 60 PRs/hour.

### 2. Stale score fading

When a refresh detects that CI or conflict status actually changed from what's displayed, the score cells (Ready/Need/Action) fade to ~45% opacity. This signals that the server-computed scores may no longer be accurate. If nothing changed, scores stay at full opacity.

### 3. Rate limit footer

After the first API call, a light-gray footer appears at the bottom of the page showing the remaining GitHub API budget: `API: 47/60 remaining · resets in 38min`. Updated after each call.

### Files changed

- `docs/pr-refresh.js` — refresh logic, rate limit display
- `docs/shared-styles.css` — `.scores-stale` and `.rate-limit-footer` styles
