### PR TITLE
Add incremental PR scanning to reduce API quota usage

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -108,9 +108,14 @@ jobs:
             if [ -n "$maintainers" ]; then
               maintainer_args="-Maintainers $maintainers"
             fi
+            # Pass previous scan for incremental mode (reuse cached data for unchanged PRs)
+            prev_scan_args=""
+            if [ -f "docs/${slug}/scan.json" ]; then
+              prev_scan_args="-PreviousScanFile docs/${slug}/scan.json"
+            fi
             # Write scan to temp file; only overwrite scan.json if valid JSON
             scan_ok=true
-            if ! pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args > "docs/${slug}/scan.json.tmp"; then
+            if ! pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args $prev_scan_args > "docs/${slug}/scan.json.tmp"; then
               echo "::warning::Scan failed for $repo"
               scan_ok=false
             fi

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -84,6 +84,10 @@ jobs:
             "dotnet/skills:skills:standard"
             "dotnet/maui:maui:standard"
           )
+          # Log API quota at job start (single call, no per-repo overhead)
+          rate_start=$(gh api rate_limit 2>/dev/null || echo "")
+          rest_start=$(echo "$rate_start" | jq -r '.resources.core.remaining // empty' 2>/dev/null || echo "")
+          graphql_start=$(echo "$rate_start" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || echo "")
           for entry in "${repos[@]}"; do
             IFS=':' read -r repo slug tier <<< "$entry"
 
@@ -113,41 +117,20 @@ jobs:
             if [ -f "docs/${slug}/scan.json" ]; then
               prev_scan_args="-PreviousScanFile docs/${slug}/scan.json"
             fi
-            # Track API quota usage before scan (REST core + GraphQL in one call)
-            rate_json_before=$(gh api rate_limit 2>/dev/null || echo "")
-            rest_before=$(echo "$rate_json_before" | jq -r '.resources.core.remaining // empty' 2>/dev/null || echo "")
-            graphql_before=$(echo "$rate_json_before" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || echo "")
             # Write scan to temp file; only overwrite scan.json if valid JSON
             scan_ok=true
             if ! pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args $prev_scan_args > "docs/${slug}/scan.json.tmp"; then
               echo "::warning::Scan failed for $repo"
               scan_ok=false
             fi
-            # Log API quota consumed for this repo (REST and GraphQL)
-            if [ -n "$rest_before" ] || [ -n "$graphql_before" ]; then
-              rate_json_after=$(gh api rate_limit 2>/dev/null || echo "")
-              rest_after=$(echo "$rate_json_after" | jq -r '.resources.core.remaining // empty' 2>/dev/null || echo "")
-              graphql_after=$(echo "$rate_json_after" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || echo "")
-              if [ -n "$rest_after" ] || [ -n "$graphql_after" ]; then
-                incremental_info=""
-                if $scan_ok && [ -f "docs/${slug}/scan.json.tmp" ]; then
-                  refreshed=$(pwsh -Command "(Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json).incremental.refreshed" 2>/dev/null || echo "?")
-                  reused=$(pwsh -Command "(Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json).incremental.reused" 2>/dev/null || echo "?")
-                  incremental_info=" (refreshed ${refreshed}, reused ${reused})"
-                fi
-                quota_parts=""
-                if [ -n "$rest_before" ] && [ -n "$rest_after" ]; then
-                  rest_used=$((rest_before - rest_after))
-                  # Guard against negative delta if the rate-limit window reset between calls
-                  [ "$rest_used" -lt 0 ] && rest_used=0
-                  quota_parts="REST: ~${rest_used} used, ${rest_after} remaining"
-                fi
-                if [ -n "$graphql_after" ]; then
-                  [ -n "$quota_parts" ] && quota_parts="${quota_parts}; "
-                  quota_parts="${quota_parts}GraphQL: ${graphql_after} remaining"
-                fi
-                echo "::notice::${repo}${incremental_info} — ${quota_parts}"
-              fi
+            # Log incremental scan stats (no extra API calls)
+            if $scan_ok && [ -f "docs/${slug}/scan.json.tmp" ]; then
+              incremental_info=$(pwsh -Command "
+                \$j = Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json
+                if (\$j.incremental) { \"(refreshed \$(\$j.incremental.refreshed), reused \$(\$j.incremental.reused))\" }
+                else { '(full scan)' }
+              " 2>/dev/null || echo "")
+              echo "::notice::${repo} ${incremental_info}"
             fi
             # Validate the output is parseable JSON with a prs array
             if $scan_ok && pwsh -Command "(\$j = Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json) -and \$j.prs -ne \$null" > /dev/null 2>&1; then
@@ -167,6 +150,25 @@ jobs:
               continue
             fi
           done
+          # Log total API quota consumed across all repos (2 calls total, not per-repo)
+          rate_end=$(gh api rate_limit 2>/dev/null || echo "")
+          rest_end=$(echo "$rate_end" | jq -r '.resources.core.remaining // empty' 2>/dev/null || echo "")
+          graphql_end=$(echo "$rate_end" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || echo "")
+          quota_summary=""
+          if [ -n "$rest_start" ] && [ -n "$rest_end" ]; then
+            rest_used=$((rest_start - rest_end))
+            [ "$rest_used" -lt 0 ] && rest_used=0
+            quota_summary="REST: ~${rest_used} used, ${rest_end} remaining"
+          fi
+          if [ -n "$graphql_start" ] && [ -n "$graphql_end" ]; then
+            graphql_used=$((graphql_start - graphql_end))
+            [ "$graphql_used" -lt 0 ] && graphql_used=0
+            [ -n "$quota_summary" ] && quota_summary="${quota_summary}; "
+            quota_summary="${quota_summary}GraphQL: ~${graphql_used} used, ${graphql_end} remaining"
+          fi
+          if [ -n "$quota_summary" ]; then
+            echo "::notice::Total API usage — ${quota_summary}"
+          fi
           if [ ${#failed[@]} -gt 0 ]; then
             echo "::warning::Failed repos: ${failed[*]}"
             echo "FAILED_REPOS=${failed[*]}" >> "$GITHUB_ENV"

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -113,11 +113,27 @@ jobs:
             if [ -f "docs/${slug}/scan.json" ]; then
               prev_scan_args="-PreviousScanFile docs/${slug}/scan.json"
             fi
+            # Track API quota usage before scan
+            rate_before=$(gh api rate_limit --jq '.rate.remaining' 2>/dev/null || echo "")
             # Write scan to temp file; only overwrite scan.json if valid JSON
             scan_ok=true
             if ! pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args $prev_scan_args > "docs/${slug}/scan.json.tmp"; then
               echo "::warning::Scan failed for $repo"
               scan_ok=false
+            fi
+            # Log API quota consumed for this repo
+            if [ -n "$rate_before" ]; then
+              rate_after=$(gh api rate_limit --jq '.rate.remaining' 2>/dev/null || echo "")
+              if [ -n "$rate_after" ]; then
+                calls_used=$((rate_before - rate_after))
+                incremental_info=""
+                if $scan_ok && [ -f "docs/${slug}/scan.json.tmp" ]; then
+                  refreshed=$(pwsh -Command "(Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json).incremental.refreshed" 2>/dev/null || echo "?")
+                  reused=$(pwsh -Command "(Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json).incremental.reused" 2>/dev/null || echo "?")
+                  incremental_info=" (refreshed ${refreshed}, reused ${reused})"
+                fi
+                echo "::notice::${repo} used ${calls_used} API calls${incremental_info} — ${rate_after} remaining"
+              fi
             fi
             # Validate the output is parseable JSON with a prs array
             if $scan_ok && pwsh -Command "(\$j = Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json) -and \$j.prs -ne \$null" > /dev/null 2>&1; then

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -113,26 +113,40 @@ jobs:
             if [ -f "docs/${slug}/scan.json" ]; then
               prev_scan_args="-PreviousScanFile docs/${slug}/scan.json"
             fi
-            # Track API quota usage before scan
-            rate_before=$(gh api rate_limit --jq '.rate.remaining' 2>/dev/null || echo "")
+            # Track API quota usage before scan (REST core + GraphQL in one call)
+            rate_json_before=$(gh api rate_limit 2>/dev/null || echo "")
+            rest_before=$(echo "$rate_json_before" | jq -r '.resources.core.remaining // empty' 2>/dev/null || echo "")
+            graphql_before=$(echo "$rate_json_before" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || echo "")
             # Write scan to temp file; only overwrite scan.json if valid JSON
             scan_ok=true
             if ! pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args $prev_scan_args > "docs/${slug}/scan.json.tmp"; then
               echo "::warning::Scan failed for $repo"
               scan_ok=false
             fi
-            # Log API quota consumed for this repo
-            if [ -n "$rate_before" ]; then
-              rate_after=$(gh api rate_limit --jq '.rate.remaining' 2>/dev/null || echo "")
-              if [ -n "$rate_after" ]; then
-                calls_used=$((rate_before - rate_after))
+            # Log API quota consumed for this repo (REST and GraphQL)
+            if [ -n "$rest_before" ] || [ -n "$graphql_before" ]; then
+              rate_json_after=$(gh api rate_limit 2>/dev/null || echo "")
+              rest_after=$(echo "$rate_json_after" | jq -r '.resources.core.remaining // empty' 2>/dev/null || echo "")
+              graphql_after=$(echo "$rate_json_after" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || echo "")
+              if [ -n "$rest_after" ] || [ -n "$graphql_after" ]; then
                 incremental_info=""
                 if $scan_ok && [ -f "docs/${slug}/scan.json.tmp" ]; then
                   refreshed=$(pwsh -Command "(Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json).incremental.refreshed" 2>/dev/null || echo "?")
                   reused=$(pwsh -Command "(Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json).incremental.reused" 2>/dev/null || echo "?")
                   incremental_info=" (refreshed ${refreshed}, reused ${reused})"
                 fi
-                echo "::notice::${repo} used ${calls_used} API calls${incremental_info} — ${rate_after} remaining"
+                quota_parts=""
+                if [ -n "$rest_before" ] && [ -n "$rest_after" ]; then
+                  rest_used=$((rest_before - rest_after))
+                  # Guard against negative delta if the rate-limit window reset between calls
+                  [ "$rest_used" -lt 0 ] && rest_used=0
+                  quota_parts="REST: ~${rest_used} used, ${rest_after} remaining"
+                fi
+                if [ -n "$graphql_after" ]; then
+                  [ -n "$quota_parts" ] && quota_parts="${quota_parts}; "
+                  quota_parts="${quota_parts}GraphQL: ${graphql_after} remaining"
+                fi
+                echo "::notice::${repo}${incremental_info} — ${quota_parts}"
               fi
             fi
             # Validate the output is parseable JSON with a prs array

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -71,7 +71,7 @@ try {
     # Return sentinel cache version 0 so it never matches a real cache, ensuring all-refresh.
     function Get-IncrementalCacheVersion { 0 }
     function Import-PreviousScan { param([string]$Path, [int]$RequiredCacheVersion, [string]$Repo = ''); @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null; DisableReason = 'module unavailable' } }
-    function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, $PreviousTimestamp, [int]$MaxReuseSeconds = 43200); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
+    function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, [int]$MaxReuseSeconds = 43200); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
     function Merge-ReusedEntries { param([hashtable]$ReusedEntries, [array]$PrListData, [array]$Results); $Results }
 }
 $CacheVersion = Get-IncrementalCacheVersion
@@ -296,8 +296,7 @@ if ($incrementalEnabled) {
     $partition = Get-IncrementalPartition `
         -Candidates $candidates `
         -PreviousPrLookup $previousPrLookup `
-        -PreviousFingerprints $previousFingerprints `
-        -PreviousTimestamp $previousTimestamp
+        -PreviousFingerprints $previousFingerprints
     $refreshCandidates = $partition.RefreshCandidates
     $reusedPrEntries = $partition.ReusedEntries
     $reusedCount = $reusedPrEntries.Count

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -40,10 +40,32 @@ param(
     [int]$Limit = 500,
     [string]$Repo = "dotnet/runtime",
     [string[]]$Maintainers = @(),
+    [string]$PreviousScanFile,
     [switch]$OutputCsv
 )
 
 $ErrorActionPreference = "Stop"
+
+# Import incremental scan helpers (fingerprint, partitioning, cache loading)
+$incrementalModule = Join-Path $PSScriptRoot 'IncrementalScan.psm1'
+try {
+    if (Test-Path $incrementalModule) {
+        Import-Module $incrementalModule -Force
+    } else { throw "Module file not found" }
+} catch {
+    # Full fallback shims — script works standalone but incremental mode effectively disabled
+    Write-Verbose "IncrementalScan module unavailable ($_) — using inline fallbacks"
+    function Get-PrFingerprint($pr) {
+        $labelsSorted = ($pr.labels | ForEach-Object { $_.name } | Sort-Object) -join ','
+        $assigneesSorted = ($pr.assignees | ForEach-Object { $_.login } | Sort-Object) -join ','
+        return "$($pr.updatedAt)|$($pr.mergeable)|$($pr.isDraft)|$labelsSorted|$assigneesSorted|$($pr.changedFiles)|$($pr.additions)|$($pr.deletions)"
+    }
+    function Get-IncrementalCacheVersion { 2 }
+    function Import-PreviousScan { param([string]$Path, [int]$RequiredCacheVersion); @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null } }
+    function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, $PreviousTimestamp, [int]$MaxReuseSeconds = 43200); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
+    function Merge-ReusedEntries { param([hashtable]$ReusedEntries, [array]$PrListData, [array]$Results); $Results }
+}
+$CacheVersion = Get-IncrementalCacheVersion
 
 # Retry wrapper for gh CLI calls (handles transient HTTP 5xx / 429 errors)
 function Invoke-GhRetry {
@@ -166,6 +188,18 @@ if ($codeownersModuleLoaded) {
 
 $communityTriagers = @()  # Community triagers cannot merge or sign off; treat as regular reviewers
 
+# --- Load previous scan for incremental mode ---
+$prevScanResult = Import-PreviousScan -Path $PreviousScanFile -RequiredCacheVersion $CacheVersion
+$previousPrLookup = $prevScanResult.PrLookup
+$previousFingerprints = $prevScanResult.Fingerprints
+$previousTimestamp = $prevScanResult.Timestamp
+$incrementalEnabled = $prevScanResult.Enabled
+if ($incrementalEnabled) {
+    Write-Verbose "Incremental mode: loaded $($previousPrLookup.Count) PRs from previous scan (cache v$CacheVersion)"
+} elseif ($PreviousScanFile) {
+    Write-Verbose "Incremental mode disabled — will do full scan"
+}
+
 # --- Step 1: List PRs ---
 Write-Verbose "Fetching PR list..."
 $listArgs = @("pr","list","--repo",$Repo,"--state","open","--limit",$Limit,
@@ -228,17 +262,41 @@ Write-Verbose "Scanned $($prsRaw.Count) -> $($candidates.Count) candidates ($exc
 
 if ($candidates.Count -eq 0) {
     Write-Verbose "No candidates to analyze."
-    @{ scanned = $prsRaw.Count; analyzed = 0; prs = @() } | ConvertTo-Json -Depth 5
+    @{ scanned = $prsRaw.Count; analyzed = 0; prs = @(); _cache_version = $CacheVersion } | ConvertTo-Json -Depth 5
     return
 }
 
+# --- Step 2b: Incremental partitioning (skip GraphQL for unchanged PRs) ---
+$reusedPrEntries = @{}
+$refreshCandidates = $candidates
+$reusedCount = 0
+$incrementalFallback = $false
+if ($incrementalEnabled) {
+    $partition = Get-IncrementalPartition `
+        -Candidates $candidates `
+        -PreviousPrLookup $previousPrLookup `
+        -PreviousFingerprints $previousFingerprints `
+        -PreviousTimestamp $previousTimestamp
+    $refreshCandidates = $partition.RefreshCandidates
+    $reusedPrEntries = $partition.ReusedEntries
+    $reusedCount = $reusedPrEntries.Count
+    $incrementalFallback = $partition.Fallback
+    if ($incrementalFallback) {
+        Write-Warning "Incremental partitioning failed — falling back to full scan"
+        if ($env:GITHUB_ACTIONS) { Write-Host "::warning::Incremental scan failed for $Repo — fell back to full scan" }
+    } else {
+        Write-Verbose "Incremental: $($refreshCandidates.Count) to refresh, $reusedCount reused from cache"
+    }
+}
+
 # --- Step 3: Batched GraphQL (reviews, threads, Build Analysis, thread authors, changed files) ---
+# Only fetch details for PRs that need refreshing (all of them if incremental is disabled)
 $fragment = 'number comments(last:20){totalCount nodes{author{login}createdAt}} reviews(last:10){nodes{author{login}state commit{oid}}} reviewRequests(first:10){nodes{requestedReviewer{...on User{login}...on Team{name}}}} reviewThreads(first:50){nodes{isResolved comments(first:5){nodes{author{login}createdAt}}}} commits(last:1){nodes{commit{oid statusCheckRollup{contexts(first:100){pageInfo{hasNextPage endCursor} nodes{...on CheckRun{name conclusion status}}}}}}} files(first:100){nodes{path}}'
 
 $graphqlData = @{}
 $batches = [System.Collections.ArrayList]@()
 $batch = [System.Collections.ArrayList]@()
-foreach ($pr in $candidates) {
+foreach ($pr in $refreshCandidates) {
     [void]$batch.Add($pr.number)
     if ($batch.Count -eq 10) {
         [void]$batches.Add([long[]]$batch.ToArray())
@@ -346,7 +404,7 @@ if ($prsWithCopilotReview.Count -gt 0) {
 
 # --- Step 4c: Detect who triggered Copilot-authored PRs (isolated query to avoid breaking main batch) ---
 $copilotTriggers = @{}
-$copilotAuthoredPRs = @($candidates | Where-Object { $_.author.login -match "^(app/)?copilot-swe-agent$" })
+$copilotAuthoredPRs = @($refreshCandidates | Where-Object { $_.author.login -match "^(app/)?copilot-swe-agent$" })
 if ($copilotAuthoredPRs.Count -gt 0) {
     $triggerBatches = [System.Collections.ArrayList]@()
     $tb = [System.Collections.ArrayList]@()
@@ -377,11 +435,11 @@ if ($copilotAuthoredPRs.Count -gt 0) {
     Write-Verbose "Found trigger user for $($copilotTriggers.Count) of $($copilotAuthoredPRs.Count) Copilot PR(s)"
 }
 
-# --- Step 5: Score each PR ---
+# --- Step 5: Score each PR (only refresh candidates; reused PRs are carried forward) ---
 $now = Get-Date
 $results = @()
 
-foreach ($pr in $candidates) {
+foreach ($pr in $refreshCandidates) {
     $n = $pr.number
     $gql = $graphqlData[$n]
     $labelNames = @($pr.labels | ForEach-Object { $_.name })
@@ -994,7 +1052,14 @@ foreach ($pr in $candidates) {
         involved = $involvedList
         blockers = $blockersStr
         why = $whyStr
+        _fingerprint = (Get-PrFingerprint $pr)
     }
+}
+
+# --- Step 5b: Merge carried-forward PRs from incremental cache ---
+$results = Merge-ReusedEntries -ReusedEntries $reusedPrEntries -PrListData $prsRaw -Results $results
+if ($reusedPrEntries.Count -gt 0) {
+    Write-Verbose "Merged $($reusedPrEntries.Count) carried-forward PR(s) into results"
 }
 
 # Sort by action_score descending (combined merge readiness + value)
@@ -1048,6 +1113,13 @@ $output = @{
         next_action = if ($NextAction) { $NextAction } else { $null }
         my_actions = if ($MyActions) { $MyActions } else { $null }
         top = $Top
+    }
+    _cache_version = $CacheVersion
+    incremental = @{
+        refreshed = $refreshCandidates.Count
+        reused = $reusedPrEntries.Count
+        full_scan = (-not $incrementalEnabled -or $incrementalFallback)
+        fallback = $incrementalFallback
     }
     owners = $owners
     scanned = $prsRaw.Count

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -16,9 +16,10 @@
 .PARAMETER PreviousScanFile
     Path to a previous scan.json from a prior run. When provided and valid,
     enables incremental mode: only PRs whose fingerprint has changed since the
-    last scan are re-fetched via expensive GraphQL calls. Falls back silently
-    to a full scan if the file is missing, corrupt, or from a different repo
-    or cache version.
+    last scan are re-fetched via expensive GraphQL calls. Falls back to a
+    full scan if the file is missing, corrupt, or from a different repo or
+    cache version; when a previous scan file was explicitly provided, a
+    warning is emitted to explain why incremental mode was not used.
 .EXAMPLE
     .\Get-PrTriageData.ps1 -Label "area-CodeGen-coreclr"
 #>

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -66,8 +66,10 @@ try {
         $assigneesSorted = ($pr.assignees | ForEach-Object { $_.login } | Sort-Object) -join ','
         return "$($pr.updatedAt)|$($pr.mergeable)|$($pr.isDraft)|$labelsSorted|$assigneesSorted|$($pr.changedFiles)|$($pr.additions)|$($pr.deletions)"
     }
-    function Get-IncrementalCacheVersion { 2 }
-    function Import-PreviousScan { param([string]$Path, [int]$RequiredCacheVersion, [string]$Repo = ''); @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null } }
+    # Fallback shims — script works standalone but incremental mode is explicitly disabled.
+    # Return sentinel cache version 0 so it never matches a real cache, ensuring all-refresh.
+    function Get-IncrementalCacheVersion { 0 }
+    function Import-PreviousScan { param([string]$Path, [int]$RequiredCacheVersion, [string]$Repo = ''); @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null; DisableReason = 'module unavailable' } }
     function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, $PreviousTimestamp, [int]$MaxReuseSeconds = 43200); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
     function Merge-ReusedEntries { param([hashtable]$ReusedEntries, [array]$PrListData, [array]$Results); $Results }
 }
@@ -203,7 +205,12 @@ $incrementalEnabled = $prevScanResult.Enabled
 if ($incrementalEnabled) {
     Write-Verbose "Incremental mode: loaded $($previousPrLookup.Count) PRs from previous scan (cache v$CacheVersion)"
 } elseif ($PreviousScanFile) {
-    Write-Verbose "Incremental mode disabled — will do full scan"
+    $reason = if ($prevScanResult.DisableReason) { $prevScanResult.DisableReason } else { 'unknown' }
+    $msg = "Incremental mode disabled — full scan. Reason: $reason"
+    Write-Warning $msg
+    if ($env:GITHUB_ACTIONS) {
+        Write-Output "::warning::$msg"
+    }
 }
 
 # --- Step 1: List PRs ---

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -1066,6 +1066,7 @@ foreach ($pr in $refreshCandidates) {
         blockers = $blockersStr
         why = $whyStr
         _fingerprint = (Get-PrFingerprint $pr)
+        _refreshed_at = $now.ToString("o")
     }
 }
 

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -13,6 +13,12 @@
 .PARAMETER Maintainers
     Optional list of usernames to treat as area owners (fallback when
     area-owners.md is missing or has no match for a PR's labels).
+.PARAMETER PreviousScanFile
+    Path to a previous scan.json from a prior run. When provided and valid,
+    enables incremental mode: only PRs whose fingerprint has changed since the
+    last scan are re-fetched via expensive GraphQL calls. Falls back silently
+    to a full scan if the file is missing, corrupt, or from a different repo
+    or cache version.
 .EXAMPLE
     .\Get-PrTriageData.ps1 -Label "area-CodeGen-coreclr"
 #>
@@ -61,7 +67,7 @@ try {
         return "$($pr.updatedAt)|$($pr.mergeable)|$($pr.isDraft)|$labelsSorted|$assigneesSorted|$($pr.changedFiles)|$($pr.additions)|$($pr.deletions)"
     }
     function Get-IncrementalCacheVersion { 2 }
-    function Import-PreviousScan { param([string]$Path, [int]$RequiredCacheVersion); @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null } }
+    function Import-PreviousScan { param([string]$Path, [int]$RequiredCacheVersion, [string]$Repo = ''); @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null } }
     function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, $PreviousTimestamp, [int]$MaxReuseSeconds = 43200); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
     function Merge-ReusedEntries { param([hashtable]$ReusedEntries, [array]$PrListData, [array]$Results); $Results }
 }
@@ -189,7 +195,7 @@ if ($codeownersModuleLoaded) {
 $communityTriagers = @()  # Community triagers cannot merge or sign off; treat as regular reviewers
 
 # --- Load previous scan for incremental mode ---
-$prevScanResult = Import-PreviousScan -Path $PreviousScanFile -RequiredCacheVersion $CacheVersion
+$prevScanResult = Import-PreviousScan -Path $PreviousScanFile -RequiredCacheVersion $CacheVersion -Repo $Repo
 $previousPrLookup = $prevScanResult.PrLookup
 $previousFingerprints = $prevScanResult.Fingerprints
 $previousTimestamp = $prevScanResult.Timestamp

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -268,7 +268,14 @@ Write-Verbose "Scanned $($prsRaw.Count) -> $($candidates.Count) candidates ($exc
 
 if ($candidates.Count -eq 0) {
     Write-Verbose "No candidates to analyze."
-    @{ scanned = $prsRaw.Count; analyzed = 0; prs = @(); _cache_version = $CacheVersion } | ConvertTo-Json -Depth 5
+    @{
+        repo = $Repo
+        timestamp = $now.ToString("o")
+        scanned = $prsRaw.Count
+        analyzed = 0
+        prs = @()
+        _cache_version = $CacheVersion
+    } | ConvertTo-Json -Depth 5
     return
 }
 

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -47,7 +47,7 @@ function Import-PreviousScan {
             $result.DisableReason = "cache version mismatch (got $($prevScan._cache_version), need $RequiredCacheVersion)"
             return $result
         }
-        if (-not $prevScan.prs) {
+        if ($null -eq $prevScan.prs) {
             $result.DisableReason = 'no prs array in previous scan'
             return $result
         }

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -1,0 +1,168 @@
+<#
+.SYNOPSIS
+    Helpers for incremental PR scanning — extracted for testability.
+    Used by Get-PrTriageData.ps1 to skip expensive GraphQL calls for unchanged PRs.
+#>
+
+# Cache version — bump when scoring logic or output schema changes.
+$script:CacheVersion = 2
+
+# Max age in seconds before cache is considered stale and all PRs are refreshed.
+$script:MaxReuseSec = 12 * 3600
+
+function Get-IncrementalCacheVersion { $script:CacheVersion }
+
+function Get-PrFingerprint {
+    <#
+    .SYNOPSIS
+        Build a fingerprint from cheap PR list data for change detection.
+        Changes to any of these fields trigger a full GraphQL re-fetch for that PR.
+    #>
+    param([Parameter(Mandatory)]$pr)
+    $labelsSorted = ($pr.labels | ForEach-Object { $_.name } | Sort-Object) -join ','
+    $assigneesSorted = ($pr.assignees | ForEach-Object { $_.login } | Sort-Object) -join ','
+    return "$($pr.updatedAt)|$($pr.mergeable)|$($pr.isDraft)|$labelsSorted|$assigneesSorted|$($pr.changedFiles)|$($pr.additions)|$($pr.deletions)"
+}
+
+function Import-PreviousScan {
+    <#
+    .SYNOPSIS
+        Load and validate a previous scan.json for incremental reuse.
+    .OUTPUTS
+        Hashtable with keys: Enabled, PrLookup, Fingerprints, Timestamp
+    #>
+    param(
+        [string]$Path,
+        [int]$RequiredCacheVersion
+    )
+    $result = @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null }
+    if (-not $Path -or -not (Test-Path $Path)) { return $result }
+    try {
+        $prevScan = Get-Content $Path -Raw | ConvertFrom-Json
+        if ($prevScan._cache_version -eq $RequiredCacheVersion -and $prevScan.prs) {
+            foreach ($p in $prevScan.prs) {
+                $key = [string]$p.number
+                $result.PrLookup[$key] = $p
+                if ($p._fingerprint) { $result.Fingerprints[$key] = $p._fingerprint }
+            }
+            $result.Timestamp = if ($prevScan.timestamp) { [DateTime]::Parse($prevScan.timestamp) } else { $null }
+            $result.Enabled = $true
+        }
+    } catch {
+        # Fail safe: return disabled — caller will do a full scan
+    }
+    return $result
+}
+
+function Get-IncrementalPartition {
+    <#
+    .SYNOPSIS
+        Partition PR candidates into refresh vs reuse sets.
+    .DESCRIPTION
+        Compares current PR fingerprints against previous scan data.
+        PRs are forced to refresh when:
+        - No previous entry or fingerprint exists (new PR)
+        - Fingerprint changed (labels, mergeable, draft status, etc.)
+        - Previous CI was non-terminal (IN_PROGRESS or ABSENT)
+        - Previous mergeable was UNKNOWN
+        - Cache TTL exceeded (MaxReuseSeconds)
+        - Previous entry is missing required fields (corrupt)
+    .OUTPUTS
+        Hashtable with keys: RefreshCandidates, ReusedEntries, Fallback
+    #>
+    param(
+        [array]$Candidates,
+        [hashtable]$PreviousPrLookup,
+        [hashtable]$PreviousFingerprints,
+        [AllowNull()][Nullable[DateTime]]$PreviousTimestamp = $null,
+        [int]$MaxReuseSeconds = 43200  # 12h default
+    )
+    $result = @{
+        RefreshCandidates = $Candidates
+        ReusedEntries = @{}
+        Fallback = $false
+    }
+
+    try {
+        $refresh = [System.Collections.ArrayList]@()
+        $reused = @{}
+        $cacheAgeSec = if ($PreviousTimestamp) { ((Get-Date) - $PreviousTimestamp).TotalSeconds } else { [double]::MaxValue }
+        $cacheExpired = $cacheAgeSec -gt $MaxReuseSeconds
+
+        foreach ($pr in $Candidates) {
+            $key = [string]$pr.number
+            $currentFp = Get-PrFingerprint $pr
+            $prevEntry = $PreviousPrLookup[$key]
+            $prevFp = $PreviousFingerprints[$key]
+            $mustRefresh = $false
+
+            if ($cacheExpired) {
+                $mustRefresh = $true
+            } elseif (-not $prevEntry -or -not $prevFp) {
+                $mustRefresh = $true
+            } elseif ($currentFp -ne $prevFp) {
+                $mustRefresh = $true
+            } elseif ($prevEntry.ci -ne 'SUCCESS') {
+                $mustRefresh = $true  # non-success CI can change via rerun without PR fields changing
+            } elseif ($prevEntry.mergeable -eq 'UNKNOWN') {
+                $mustRefresh = $true
+            }
+
+            if ($mustRefresh) {
+                [void]$refresh.Add($pr)
+            } else {
+                if ($prevEntry.number -and $null -ne $prevEntry.score -and $prevEntry.next_action) {
+                    $reused[$key] = $prevEntry
+                } else {
+                    [void]$refresh.Add($pr)
+                }
+            }
+        }
+        $result.RefreshCandidates = @($refresh)
+        $result.ReusedEntries = $reused
+    } catch {
+        $result.RefreshCandidates = $Candidates
+        $result.ReusedEntries = @{}
+        $result.Fallback = $true
+    }
+
+    return $result
+}
+
+function Merge-ReusedEntries {
+    <#
+    .SYNOPSIS
+        Merge carried-forward PR entries into the results array, updating time fields.
+    .PARAMETER ReusedEntries
+        Hashtable of {string key -> previous scan entry} from Get-IncrementalPartition.
+    .PARAMETER PrListData
+        Array of raw PR objects from gh pr list (used to recalculate time fields).
+    .PARAMETER Results
+        Array of freshly-scored PR result objects to merge into.
+    .OUTPUTS
+        Combined array of results + reused entries with updated time fields.
+    #>
+    param(
+        [hashtable]$ReusedEntries,
+        [array]$PrListData,
+        [array]$Results
+    )
+    if ($ReusedEntries.Count -eq 0) { return $Results }
+
+    $now = Get-Date
+    $byNumber = @{}
+    foreach ($p in $PrListData) { $byNumber[[string]$p.number] = $p }
+
+    foreach ($entry in $ReusedEntries.Values) {
+        $listPr = $byNumber[[string]$entry.number]
+        if ($listPr) {
+            $entry.age_days = [int]($now - [DateTime]::Parse($listPr.createdAt)).TotalDays
+            $entry.days_since_update = [int]($now - [DateTime]::Parse($listPr.updatedAt)).TotalDays
+            $entry._fingerprint = Get-PrFingerprint $listPr
+        }
+        $Results += $entry
+    }
+    return $Results
+}
+
+Export-ModuleMember -Function Get-PrFingerprint, Import-PreviousScan, Get-IncrementalPartition, Get-IncrementalCacheVersion, Merge-ReusedEntries

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -7,7 +7,7 @@
 # Cache version — bump when scoring logic or output schema changes.
 $script:CacheVersion = 2
 
-# Max age in seconds before cache is considered stale and all PRs are refreshed.
+# Max age in seconds before a cached entry is considered stale (used as default for Get-IncrementalPartition).
 $script:MaxReuseSec = 12 * 3600
 
 function Get-IncrementalCacheVersion { $script:CacheVersion }
@@ -75,7 +75,7 @@ function Get-IncrementalPartition {
         [hashtable]$PreviousPrLookup,
         [hashtable]$PreviousFingerprints,
         [AllowNull()][Nullable[DateTime]]$PreviousTimestamp = $null,
-        [int]$MaxReuseSeconds = 43200  # 12h default
+        [int]$MaxReuseSeconds = $script:MaxReuseSec
     )
     $result = @{
         RefreshCandidates = $Candidates
@@ -153,6 +153,7 @@ function Merge-ReusedEntries {
     $byNumber = @{}
     foreach ($p in $PrListData) { $byNumber[[string]$p.number] = $p }
 
+    $merged = [System.Collections.ArrayList]@($Results)
     foreach ($entry in $ReusedEntries.Values) {
         $listPr = $byNumber[[string]$entry.number]
         if ($listPr) {
@@ -160,9 +161,9 @@ function Merge-ReusedEntries {
             $entry.days_since_update = [int]($now - [DateTime]::Parse($listPr.updatedAt)).TotalDays
             $entry._fingerprint = Get-PrFingerprint $listPr
         }
-        $Results += $entry
+        [void]$merged.Add($entry)
     }
-    return $Results
+    return @($merged)
 }
 
 Export-ModuleMember -Function Get-PrFingerprint, Import-PreviousScan, Get-IncrementalPartition, Get-IncrementalCacheVersion, Merge-ReusedEntries

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -33,13 +33,24 @@ function Import-PreviousScan {
     #>
     param(
         [string]$Path,
-        [int]$RequiredCacheVersion
+        [int]$RequiredCacheVersion,
+        [string]$Repo = ''
     )
     $result = @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null }
     if (-not $Path -or -not (Test-Path $Path)) { return $result }
     try {
         $prevScan = Get-Content $Path -Raw | ConvertFrom-Json
         if ($prevScan._cache_version -eq $RequiredCacheVersion -and $prevScan.prs) {
+            # Validate repo matches to prevent cross-repo PR number collisions.
+            # If prevScan.repo is absent (legacy scans pre-dating the repo field), allow
+            # incremental mode rather than forcing a full scan for existing deployments.
+            if ($Repo -and $prevScan.repo -and $prevScan.repo -ne $Repo) {
+                Write-Warning "Previous scan repo '$($prevScan.repo)' does not match current repo '$Repo' — disabling incremental mode"
+                return $result
+            }
+            if ($Repo -and -not $prevScan.repo) {
+                Write-Verbose "Previous scan has no repo field (legacy) — proceeding with incremental mode for '$Repo'"
+            }
             foreach ($p in $prevScan.prs) {
                 $key = [string]$p.number
                 $result.PrLookup[$key] = $p
@@ -132,15 +143,15 @@ function Get-IncrementalPartition {
 function Merge-ReusedEntries {
     <#
     .SYNOPSIS
-        Merge carried-forward PR entries into the results array, updating time fields.
+        Merge carried-forward PR entries into the results array, updating fingerprints.
     .PARAMETER ReusedEntries
         Hashtable of {string key -> previous scan entry} from Get-IncrementalPartition.
     .PARAMETER PrListData
-        Array of raw PR objects from gh pr list (used to recalculate time fields).
+        Array of raw PR objects from gh pr list (used to refresh fingerprints).
     .PARAMETER Results
         Array of freshly-scored PR result objects to merge into.
     .OUTPUTS
-        Combined array of results + reused entries with updated time fields.
+        Combined array of results + reused entries with updated fingerprints.
     #>
     param(
         [hashtable]$ReusedEntries,
@@ -149,7 +160,6 @@ function Merge-ReusedEntries {
     )
     if ($ReusedEntries.Count -eq 0) { return $Results }
 
-    $now = Get-Date
     $byNumber = @{}
     foreach ($p in $PrListData) { $byNumber[[string]$p.number] = $p }
 
@@ -157,8 +167,12 @@ function Merge-ReusedEntries {
     foreach ($entry in $ReusedEntries.Values) {
         $listPr = $byNumber[[string]$entry.number]
         if ($listPr) {
-            $entry.age_days = [int]($now - [DateTime]::Parse($listPr.createdAt)).TotalDays
-            $entry.days_since_update = [int]($now - [DateTime]::Parse($listPr.updatedAt)).TotalDays
+            # Only update _fingerprint for next-run comparison.
+            # age_days/days_since_update are intentionally NOT recalculated here:
+            # updating them without recomputing score/next_action would make scan.json
+            # internally inconsistent (e.g., days_since_update crosses a threshold but
+            # the score still reflects the older value). PRs near thresholds are
+            # expected to get a full re-fetch on the next run once the fingerprint changes.
             $entry._fingerprint = Get-PrFingerprint $listPr
         }
         [void]$merged.Add($entry)

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -94,7 +94,6 @@ function Get-IncrementalPartition {
         [array]$Candidates,
         [hashtable]$PreviousPrLookup,
         [hashtable]$PreviousFingerprints,
-        [AllowNull()][Nullable[DateTime]]$PreviousTimestamp = $null,
         [int]$MaxReuseSeconds = $script:MaxReuseSec
     )
     $result = @{

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -97,8 +97,7 @@ function Get-IncrementalPartition {
     try {
         $refresh = [System.Collections.ArrayList]@()
         $reused = @{}
-        $cacheAgeSec = if ($PreviousTimestamp) { ((Get-Date) - $PreviousTimestamp).TotalSeconds } else { [double]::MaxValue }
-        $cacheExpired = $cacheAgeSec -gt $MaxReuseSeconds
+        $now = Get-Date
 
         foreach ($pr in $Candidates) {
             $key = [string]$pr.number
@@ -107,9 +106,7 @@ function Get-IncrementalPartition {
             $prevFp = $PreviousFingerprints[$key]
             $mustRefresh = $false
 
-            if ($cacheExpired) {
-                $mustRefresh = $true
-            } elseif (-not $prevEntry -or -not $prevFp) {
+            if (-not $prevEntry -or -not $prevFp) {
                 $mustRefresh = $true
             } elseif ($currentFp -ne $prevFp) {
                 $mustRefresh = $true
@@ -117,6 +114,20 @@ function Get-IncrementalPartition {
                 $mustRefresh = $true  # non-success CI can change via rerun without PR fields changing
             } elseif ($prevEntry.mergeable -eq 'UNKNOWN') {
                 $mustRefresh = $true
+            } else {
+                # Per-PR TTL: use _refreshed_at (when this PR was last fully analyzed)
+                # Falls back to PreviousTimestamp for entries from before _refreshed_at was added
+                $refreshedAt = if ($prevEntry._refreshed_at) {
+                    [datetime]$prevEntry._refreshed_at
+                } elseif ($PreviousTimestamp) {
+                    $PreviousTimestamp
+                } else {
+                    [datetime]::MinValue
+                }
+                $prAgeSec = ($now - $refreshedAt).TotalSeconds
+                if ($prAgeSec -gt $MaxReuseSeconds) {
+                    $mustRefresh = $true
+                }
             }
 
             if ($mustRefresh) {
@@ -168,11 +179,10 @@ function Merge-ReusedEntries {
         $listPr = $byNumber[[string]$entry.number]
         if ($listPr) {
             # Only update _fingerprint for next-run comparison.
-            # age_days/days_since_update are intentionally NOT recalculated here:
-            # updating them without recomputing score/next_action would make scan.json
-            # internally inconsistent (e.g., days_since_update crosses a threshold but
-            # the score still reflects the older value). PRs near thresholds are
-            # expected to get a full re-fetch on the next run once the fingerprint changes.
+            # age_days/days_since_update and _refreshed_at are intentionally NOT updated:
+            # updating age without recomputing score/next_action would make scan.json
+            # internally inconsistent. _refreshed_at must reflect when the PR was last
+            # fully analyzed, so the per-PR TTL can eventually force a re-fetch.
             $entry._fingerprint = Get-PrFingerprint $listPr
         }
         [void]$merged.Add($entry)

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -74,7 +74,7 @@ function Get-IncrementalPartition {
         PRs are forced to refresh when:
         - No previous entry or fingerprint exists (new PR)
         - Fingerprint changed (labels, mergeable, draft status, etc.)
-        - Previous CI was non-terminal (IN_PROGRESS or ABSENT)
+        - Previous CI was anything other than SUCCESS (e.g. IN_PROGRESS, ABSENT, or FAILURE)
         - Previous mergeable was UNKNOWN
         - Cache TTL exceeded (MaxReuseSeconds)
         - Previous entry is missing required fields (corrupt)

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -117,12 +117,15 @@ function Get-IncrementalPartition {
             } else {
                 # Per-PR TTL: use _refreshed_at (when this PR was last fully analyzed)
                 # Falls back to PreviousTimestamp for entries from before _refreshed_at was added
-                $refreshedAt = if ($prevEntry._refreshed_at) {
-                    [datetime]$prevEntry._refreshed_at
-                } elseif ($PreviousTimestamp) {
-                    $PreviousTimestamp
-                } else {
-                    [datetime]::MinValue
+                $refreshedAt = $null
+                if ($prevEntry._refreshed_at) {
+                    try { $refreshedAt = [datetime]$prevEntry._refreshed_at } catch { }
+                }
+                if (-not $refreshedAt -and $PreviousTimestamp) {
+                    $refreshedAt = $PreviousTimestamp
+                }
+                if (-not $refreshedAt) {
+                    $refreshedAt = [datetime]::MinValue
                 }
                 $prAgeSec = ($now - $refreshedAt).TotalSeconds
                 if ($prAgeSec -gt $MaxReuseSeconds) {

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -55,7 +55,6 @@ function Import-PreviousScan {
         # If prevScan.repo is absent (legacy scans pre-dating the repo field), allow
         # incremental mode rather than forcing a full scan for existing deployments.
         if ($Repo -and $prevScan.repo -and $prevScan.repo -ne $Repo) {
-            Write-Warning "Previous scan repo '$($prevScan.repo)' does not match current repo '$Repo' — disabling incremental mode"
             $result.DisableReason = "repo mismatch ($($prevScan.repo) vs $Repo)"
             return $result
         }
@@ -125,21 +124,20 @@ function Get-IncrementalPartition {
             } elseif ($prevEntry.mergeable -eq 'UNKNOWN') {
                 $mustRefresh = $true
             } else {
-                # Per-PR TTL: use _refreshed_at (when this PR was last fully analyzed)
-                # Falls back to PreviousTimestamp for entries from before _refreshed_at was added
+                # Per-PR TTL: require a valid _refreshed_at (when this PR was last fully analyzed).
+                # Missing or malformed values indicate a legacy/corrupt cache entry — force refresh
+                # rather than relying on scan-level timestamp which advances every run.
                 $refreshedAt = $null
                 if ($prevEntry._refreshed_at) {
                     try { $refreshedAt = [datetime]$prevEntry._refreshed_at } catch { }
                 }
-                if (-not $refreshedAt -and $PreviousTimestamp) {
-                    $refreshedAt = $PreviousTimestamp
-                }
                 if (-not $refreshedAt) {
-                    $refreshedAt = [datetime]::MinValue
-                }
-                $prAgeSec = ($now - $refreshedAt).TotalSeconds
-                if ($prAgeSec -gt $MaxReuseSeconds) {
                     $mustRefresh = $true
+                } else {
+                    $prAgeSec = ($now - $refreshedAt).TotalSeconds
+                    if ($prAgeSec -gt $MaxReuseSeconds) {
+                        $mustRefresh = $true
+                    }
                 }
             }
 

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -37,30 +37,40 @@ function Import-PreviousScan {
         [string]$Repo = ''
     )
     $result = @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null }
-    if (-not $Path -or -not (Test-Path $Path)) { return $result }
+    if (-not $Path -or -not (Test-Path $Path)) {
+        $result.DisableReason = 'no previous scan file'
+        return $result
+    }
     try {
         $prevScan = Get-Content $Path -Raw | ConvertFrom-Json
-        if ($prevScan._cache_version -eq $RequiredCacheVersion -and $prevScan.prs) {
-            # Validate repo matches to prevent cross-repo PR number collisions.
-            # If prevScan.repo is absent (legacy scans pre-dating the repo field), allow
-            # incremental mode rather than forcing a full scan for existing deployments.
-            if ($Repo -and $prevScan.repo -and $prevScan.repo -ne $Repo) {
-                Write-Warning "Previous scan repo '$($prevScan.repo)' does not match current repo '$Repo' — disabling incremental mode"
-                return $result
-            }
-            if ($Repo -and -not $prevScan.repo) {
-                Write-Verbose "Previous scan has no repo field (legacy) — proceeding with incremental mode for '$Repo'"
-            }
-            foreach ($p in $prevScan.prs) {
-                $key = [string]$p.number
-                $result.PrLookup[$key] = $p
-                if ($p._fingerprint) { $result.Fingerprints[$key] = $p._fingerprint }
-            }
-            $result.Timestamp = if ($prevScan.timestamp) { [DateTime]::Parse($prevScan.timestamp) } else { $null }
-            $result.Enabled = $true
+        if ($prevScan._cache_version -ne $RequiredCacheVersion) {
+            $result.DisableReason = "cache version mismatch (got $($prevScan._cache_version), need $RequiredCacheVersion)"
+            return $result
         }
+        if (-not $prevScan.prs) {
+            $result.DisableReason = 'no prs array in previous scan'
+            return $result
+        }
+        # Validate repo matches to prevent cross-repo PR number collisions.
+        # If prevScan.repo is absent (legacy scans pre-dating the repo field), allow
+        # incremental mode rather than forcing a full scan for existing deployments.
+        if ($Repo -and $prevScan.repo -and $prevScan.repo -ne $Repo) {
+            Write-Warning "Previous scan repo '$($prevScan.repo)' does not match current repo '$Repo' — disabling incremental mode"
+            $result.DisableReason = "repo mismatch ($($prevScan.repo) vs $Repo)"
+            return $result
+        }
+        if ($Repo -and -not $prevScan.repo) {
+            Write-Verbose "Previous scan has no repo field (legacy) — proceeding with incremental mode for '$Repo'"
+        }
+        foreach ($p in $prevScan.prs) {
+            $key = [string]$p.number
+            $result.PrLookup[$key] = $p
+            if ($p._fingerprint) { $result.Fingerprints[$key] = $p._fingerprint }
+        }
+        $result.Timestamp = if ($prevScan.timestamp) { [DateTime]::Parse($prevScan.timestamp) } else { $null }
+        $result.Enabled = $true
     } catch {
-        # Fail safe: return disabled — caller will do a full scan
+        $result.DisableReason = "parse error: $_"
     }
     return $result
 }

--- a/scripts/Tests/IncrementalScan.Tests.ps1
+++ b/scripts/Tests/IncrementalScan.Tests.ps1
@@ -1,0 +1,356 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/../IncrementalScan.psm1" -Force
+
+    function New-FakePr {
+        param(
+            [int]$Number = 100,
+            [string]$UpdatedAt = '2025-01-15T10:00:00Z',
+            [string]$Mergeable = 'MERGEABLE',
+            [bool]$IsDraft = $false,
+            [string[]]$Labels = @('area-System.Net'),
+            [string[]]$Assignees = @('alice'),
+            [int]$ChangedFiles = 3,
+            [int]$Additions = 10,
+            [int]$Deletions = 5
+        )
+        [PSCustomObject]@{
+            number       = $Number
+            updatedAt    = $UpdatedAt
+            mergeable    = $Mergeable
+            isDraft      = $IsDraft
+            labels       = @($Labels | ForEach-Object { [PSCustomObject]@{ name = $_ } })
+            assignees    = @($Assignees | ForEach-Object { [PSCustomObject]@{ login = $_ } })
+            changedFiles = $ChangedFiles
+            additions    = $Additions
+            deletions    = $Deletions
+            createdAt    = '2025-01-01T00:00:00Z'
+        }
+    }
+
+    function New-FakeScanEntry {
+        param(
+            [int]$Number = 100,
+            [string]$Fingerprint = '',
+            [string]$CI = 'SUCCESS',
+            [string]$Mergeable = 'MERGEABLE',
+            [int]$Score = 50,
+            [string]$NextAction = 'needs-review'
+        )
+        [PSCustomObject]@{
+            number       = $Number
+            ci           = $CI
+            mergeable    = $Mergeable
+            score        = $Score
+            next_action  = $NextAction
+            _fingerprint = $Fingerprint
+            age_days     = 14
+            days_since_update = 2
+        }
+    }
+}
+
+Describe 'Get-PrFingerprint' {
+    It 'Builds a deterministic fingerprint from PR data' {
+        $pr = New-FakePr -Number 42
+        $fp = Get-PrFingerprint $pr
+        $fp | Should -BeLike '2025-01-15T10:00:00Z|*'
+    }
+
+    It 'Changes when labels change' {
+        $pr1 = New-FakePr -Labels @('area-A')
+        $pr2 = New-FakePr -Labels @('area-B')
+        (Get-PrFingerprint $pr1) | Should -Not -Be (Get-PrFingerprint $pr2)
+    }
+
+    It 'Changes when updatedAt changes' {
+        $pr1 = New-FakePr -UpdatedAt '2025-01-15T10:00:00Z'
+        $pr2 = New-FakePr -UpdatedAt '2025-01-15T11:00:00Z'
+        (Get-PrFingerprint $pr1) | Should -Not -Be (Get-PrFingerprint $pr2)
+    }
+
+    It 'Changes when draft status changes' {
+        $pr1 = New-FakePr -IsDraft $false
+        $pr2 = New-FakePr -IsDraft $true
+        (Get-PrFingerprint $pr1) | Should -Not -Be (Get-PrFingerprint $pr2)
+    }
+
+    It 'Changes when mergeable changes' {
+        $pr1 = New-FakePr -Mergeable 'MERGEABLE'
+        $pr2 = New-FakePr -Mergeable 'CONFLICTING'
+        (Get-PrFingerprint $pr1) | Should -Not -Be (Get-PrFingerprint $pr2)
+    }
+
+    It 'Sorts labels for stable fingerprint' {
+        $pr1 = New-FakePr -Labels @('z-label','a-label')
+        $pr2 = New-FakePr -Labels @('a-label','z-label')
+        (Get-PrFingerprint $pr1) | Should -Be (Get-PrFingerprint $pr2)
+    }
+
+    It 'Handles empty labels and assignees' {
+        $pr = New-FakePr -Labels @() -Assignees @()
+        { Get-PrFingerprint $pr } | Should -Not -Throw
+        (Get-PrFingerprint $pr) | Should -BeLike '*||*'
+    }
+}
+
+Describe 'Get-IncrementalCacheVersion' {
+    It 'Returns a positive integer' {
+        $v = Get-IncrementalCacheVersion
+        $v | Should -BeGreaterThan 0
+    }
+}
+
+Describe 'Import-PreviousScan' {
+    BeforeAll {
+        $testDir = Join-Path ([System.IO.Path]::GetTempPath()) "incr-test-$(Get-Random)"
+        New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+    }
+    AfterAll {
+        Remove-Item $testDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'Returns disabled when path is empty' {
+        $r = Import-PreviousScan -Path '' -RequiredCacheVersion 2
+        $r.Enabled | Should -BeFalse
+    }
+
+    It 'Returns disabled when file does not exist' {
+        $r = Import-PreviousScan -Path "$testDir/nope.json" -RequiredCacheVersion 2
+        $r.Enabled | Should -BeFalse
+    }
+
+    It 'Returns disabled when cache version mismatches' {
+        $file = "$testDir/scan-old.json"
+        @{ _cache_version = 1; prs = @(@{ number = 1; _fingerprint = 'fp'; score = 10; next_action = 'x' }) } |
+            ConvertTo-Json -Depth 5 | Set-Content $file
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2
+        $r.Enabled | Should -BeFalse
+    }
+
+    It 'Returns disabled for corrupt JSON' {
+        $file = "$testDir/corrupt.json"
+        'this is not json {{' | Set-Content $file
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2
+        $r.Enabled | Should -BeFalse
+    }
+
+    It 'Returns disabled when prs array is missing' {
+        $file = "$testDir/no-prs.json"
+        @{ _cache_version = 2; timestamp = '2025-01-15T12:00:00Z' } |
+            ConvertTo-Json -Depth 5 | Set-Content $file
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2
+        $r.Enabled | Should -BeFalse
+    }
+
+    It 'Loads valid previous scan and builds lookups' {
+        $file = "$testDir/valid.json"
+        @{
+            _cache_version = 2
+            timestamp = '2025-01-15T12:00:00Z'
+            prs = @(
+                @{ number = 42; _fingerprint = 'fp42'; score = 50; next_action = 'review' }
+                @{ number = 99; _fingerprint = 'fp99'; score = 30; next_action = 'merge' }
+            )
+        } | ConvertTo-Json -Depth 5 | Set-Content $file
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2
+        $r.Enabled | Should -BeTrue
+        $r.PrLookup.Count | Should -Be 2
+        $r.PrLookup['42'].score | Should -Be 50
+        $r.Fingerprints['99'] | Should -Be 'fp99'
+        $r.Timestamp | Should -BeOfType [DateTime]
+    }
+
+    It 'Uses string keys (not Int64)' {
+        $file = "$testDir/keys.json"
+        @{
+            _cache_version = 2
+            timestamp = '2025-01-15T12:00:00Z'
+            prs = @(@{ number = 12345; _fingerprint = 'fp'; score = 1; next_action = 'x' })
+        } | ConvertTo-Json -Depth 5 | Set-Content $file
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2
+        $r.PrLookup.ContainsKey('12345') | Should -BeTrue
+        $r.PrLookup.ContainsKey([int]12345) | Should -BeFalse
+    }
+}
+
+Describe 'Get-IncrementalPartition' {
+    BeforeAll {
+        # Build a valid "previous" state
+        $pr1 = New-FakePr -Number 10
+        $fp1 = Get-PrFingerprint $pr1
+        $entry1 = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -CI 'SUCCESS'
+        $pr2 = New-FakePr -Number 20
+        $fp2 = Get-PrFingerprint $pr2
+        $entry2 = New-FakeScanEntry -Number 20 -Fingerprint $fp2 -CI 'SUCCESS'
+    }
+
+    It 'Reuses unchanged PRs' {
+        $lookup = @{ '10' = $entry1; '20' = $entry2 }
+        $fpMap = @{ '10' = $fp1; '20' = $fp2 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1, $pr2) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 0
+        $partition.ReusedEntries.Count | Should -Be 2
+        $partition.Fallback | Should -BeFalse
+    }
+
+    It 'Refreshes new PRs' {
+        $newPr = New-FakePr -Number 30
+        $lookup = @{ '10' = $entry1 }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1, $newPr) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+        $partition.RefreshCandidates[0].number | Should -Be 30
+        $partition.ReusedEntries.Count | Should -Be 1
+    }
+
+    It 'Refreshes PRs with changed fingerprint' {
+        $modifiedPr = New-FakePr -Number 10 -Labels @('new-label')
+        $lookup = @{ '10' = $entry1 }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($modifiedPr) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Refreshes PRs with FAILURE CI (can change via rerun)' {
+        $failEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -CI 'FAILURE'
+        $lookup = @{ '10' = $failEntry }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Refreshes PRs with IN_PROGRESS CI' {
+        $inProgressEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -CI 'IN_PROGRESS'
+        $lookup = @{ '10' = $inProgressEntry }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Refreshes PRs with ABSENT CI' {
+        $absentEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -CI 'ABSENT'
+        $lookup = @{ '10' = $absentEntry }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Refreshes PRs with UNKNOWN mergeable' {
+        $unknownEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -Mergeable 'UNKNOWN'
+        $lookup = @{ '10' = $unknownEntry }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Force-refreshes all when TTL expired' {
+        $lookup = @{ '10' = $entry1; '20' = $entry2 }
+        $fpMap = @{ '10' = $fp1; '20' = $fp2 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1, $pr2) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddHours(-13) -MaxReuseSeconds 43200
+        $partition.RefreshCandidates.Count | Should -Be 2
+        $partition.ReusedEntries.Count | Should -Be 0
+    }
+
+    It 'Force-refreshes all when no timestamp' {
+        $lookup = @{ '10' = $entry1 }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp $null
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Refreshes entries with missing score (corrupt cache)' {
+        $corruptEntry = [PSCustomObject]@{
+            number = 10; ci = 'SUCCESS'; mergeable = 'MERGEABLE'
+            score = $null; next_action = 'x'; _fingerprint = $fp1
+        }
+        $lookup = @{ '10' = $corruptEntry }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Refreshes entries with missing next_action (corrupt cache)' {
+        $corruptEntry = [PSCustomObject]@{
+            number = 10; ci = 'SUCCESS'; mergeable = 'MERGEABLE'
+            score = 50; next_action = $null; _fingerprint = $fp1
+        }
+        $lookup = @{ '10' = $corruptEntry }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Returns all candidates on empty previous state' {
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup @{} -PreviousFingerprints @{} `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+}
+
+Describe 'Merge-ReusedEntries' {
+    It 'Returns results unchanged when no reused entries' {
+        $existing = @([PSCustomObject]@{ number = 1; score = 10 })
+        $merged = Merge-ReusedEntries -ReusedEntries @{} -PrListData @() -Results $existing
+        $merged.Count | Should -Be 1
+    }
+
+    It 'Merges reused entries and recalculates time fields' {
+        $entry = [PSCustomObject]@{
+            number = 42; score = 50; _fingerprint = 'old'
+            age_days = 999; days_since_update = 999
+        }
+        $listPr = New-FakePr -Number 42 -UpdatedAt (Get-Date).AddDays(-3).ToString('o')
+        $merged = Merge-ReusedEntries -ReusedEntries @{ '42' = $entry } `
+            -PrListData @($listPr) -Results @()
+        $merged.Count | Should -Be 1
+        $merged[0].age_days | Should -Not -Be 999
+        $merged[0].days_since_update | Should -Not -Be 999
+    }
+
+    It 'Updates fingerprint on reused entries' {
+        $listPr = New-FakePr -Number 10
+        $expectedFp = Get-PrFingerprint $listPr
+        $entry = [PSCustomObject]@{
+            number = 10; score = 50; _fingerprint = 'stale'
+            age_days = 1; days_since_update = 1
+        }
+        $merged = Merge-ReusedEntries -ReusedEntries @{ '10' = $entry } `
+            -PrListData @($listPr) -Results @()
+        $merged[0]._fingerprint | Should -Be $expectedFp
+    }
+
+    It 'Preserves existing results array' {
+        $existing = @([PSCustomObject]@{ number = 1 })
+        $entry = [PSCustomObject]@{
+            number = 2; score = 10; _fingerprint = 'fp'
+            age_days = 1; days_since_update = 1
+        }
+        $listPr = New-FakePr -Number 2
+        $merged = Merge-ReusedEntries -ReusedEntries @{ '2' = $entry } `
+            -PrListData @($listPr) -Results $existing
+        $merged.Count | Should -Be 2
+    }
+}

--- a/scripts/Tests/IncrementalScan.Tests.ps1
+++ b/scripts/Tests/IncrementalScan.Tests.ps1
@@ -330,6 +330,18 @@ Describe 'Get-IncrementalPartition' {
         $partition.ReusedEntries.Count | Should -Be 1
     }
 
+    It 'Force-refreshes when _refreshed_at is malformed (non-parseable)' {
+        $badEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -RefreshedAt 'not-a-date'
+        $lookup = @{ '10' = $badEntry }
+        $fpMap = @{ '10' = $fp1 }
+        # Malformed _refreshed_at should cause [datetime] cast to fail;
+        # fallback to PreviousTimestamp=null -> MinValue -> TTL expired -> refresh
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp $null
+        $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
     It 'Refreshes entries with missing score (corrupt cache)' {
         $corruptEntry = [PSCustomObject]@{
             number = 10; ci = 'SUCCESS'; mergeable = 'MERGEABLE'
@@ -408,5 +420,17 @@ Describe 'Merge-ReusedEntries' {
         $merged = Merge-ReusedEntries -ReusedEntries @{ '2' = $entry } `
             -PrListData @($listPr) -Results $existing
         $merged.Count | Should -Be 2
+    }
+
+    It 'Preserves _refreshed_at on reused entries (TTL correctness)' {
+        $oldTime = (Get-Date).AddHours(-6).ToString("o")
+        $entry = [PSCustomObject]@{
+            number = 42; score = 50; _fingerprint = 'old'
+            age_days = 5; days_since_update = 1; _refreshed_at = $oldTime
+        }
+        $listPr = New-FakePr -Number 42
+        $merged = Merge-ReusedEntries -ReusedEntries @{ '42' = $entry } `
+            -PrListData @($listPr) -Results @()
+        $merged[0]._refreshed_at | Should -Be $oldTime
     }
 }

--- a/scripts/Tests/IncrementalScan.Tests.ps1
+++ b/scripts/Tests/IncrementalScan.Tests.ps1
@@ -232,8 +232,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $entry1; '20' = $entry2 }
         $fpMap = @{ '10' = $fp1; '20' = $fp2 }
         $partition = Get-IncrementalPartition -Candidates @($pr1, $pr2) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 0
         $partition.ReusedEntries.Count | Should -Be 2
         $partition.Fallback | Should -BeFalse
@@ -244,8 +243,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $entry1 }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1, $newPr) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
         $partition.RefreshCandidates[0].number | Should -Be 30
         $partition.ReusedEntries.Count | Should -Be 1
@@ -256,8 +254,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $entry1 }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($modifiedPr) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
@@ -266,8 +263,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $failEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
@@ -276,8 +272,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $inProgressEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
@@ -286,8 +281,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $absentEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
@@ -296,8 +290,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $unknownEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
@@ -308,8 +301,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $staleEntry1; '20' = $staleEntry2 }
         $fpMap = @{ '10' = $fp1; '20' = $fp2 }
         $partition = Get-IncrementalPartition -Candidates @($pr1, $pr2) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5) -MaxReuseSeconds 43200
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 2
         $partition.ReusedEntries.Count | Should -Be 0
     }
@@ -320,13 +312,12 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $freshEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddHours(-13) -MaxReuseSeconds 43200
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 0
         $partition.ReusedEntries.Count | Should -Be 1
     }
 
-    It 'Force-refreshes when _refreshed_at is absent (legacy entry, no PreviousTimestamp)' {
+    It 'Force-refreshes when _refreshed_at is absent (legacy entry)' {
         $legacyEntry = [PSCustomObject]@{
             number = 10; ci = 'SUCCESS'; mergeable = 'MERGEABLE'
             score = 80; next_action = 'needs-review'; _fingerprint = $fp1
@@ -335,12 +326,11 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $legacyEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp $null
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
-    It 'Force-refreshes when _refreshed_at is absent (legacy entry, even with recent PreviousTimestamp)' {
+    It 'Force-refreshes when _refreshed_at is absent (legacy entry, second variant)' {
         $legacyEntry = [PSCustomObject]@{
             number = 10; ci = 'SUCCESS'; mergeable = 'MERGEABLE'
             score = 80; next_action = 'needs-review'; _fingerprint = $fp1
@@ -349,8 +339,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $legacyEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
@@ -360,8 +349,7 @@ Describe 'Get-IncrementalPartition' {
         $fpMap = @{ '10' = $fp1 }
         # Malformed _refreshed_at should cause [datetime] cast to fail -> force refresh
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp $null
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
@@ -373,8 +361,7 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $corruptEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
@@ -386,15 +373,13 @@ Describe 'Get-IncrementalPartition' {
         $lookup = @{ '10' = $corruptEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
     It 'Returns all candidates on empty previous state' {
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
-            -PreviousPrLookup @{} -PreviousFingerprints @{} `
-            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+            -PreviousPrLookup @{} -PreviousFingerprints @{}
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 }
@@ -457,3 +442,4 @@ Describe 'Merge-ReusedEntries' {
         $merged[0]._refreshed_at | Should -Be $oldTime
     }
 }
+

--- a/scripts/Tests/IncrementalScan.Tests.ps1
+++ b/scripts/Tests/IncrementalScan.Tests.ps1
@@ -37,6 +37,10 @@ BeforeAll {
             [string]$NextAction = 'needs-review',
             [string]$RefreshedAt = ''
         )
+        if (-not $RefreshedAt) {
+            # Default to recent timestamp so TTL doesn't force refresh in most tests
+            $RefreshedAt = (Get-Date).AddHours(-1).ToString('o')
+        }
         $entry = [PSCustomObject]@{
             number       = $Number
             ci           = $CI
@@ -46,9 +50,7 @@ BeforeAll {
             _fingerprint = $Fingerprint
             age_days     = 14
             days_since_update = 2
-        }
-        if ($RefreshedAt) {
-            $entry | Add-Member -NotePropertyName '_refreshed_at' -NotePropertyValue $RefreshedAt
+            _refreshed_at = $RefreshedAt
         }
         $entry
     }
@@ -324,8 +326,13 @@ Describe 'Get-IncrementalPartition' {
         $partition.ReusedEntries.Count | Should -Be 1
     }
 
-    It 'Force-refreshes when no _refreshed_at and no PreviousTimestamp (legacy entry)' {
-        $lookup = @{ '10' = $entry1 }
+    It 'Force-refreshes when _refreshed_at is absent (legacy entry, no PreviousTimestamp)' {
+        $legacyEntry = [PSCustomObject]@{
+            number = 10; ci = 'SUCCESS'; mergeable = 'MERGEABLE'
+            score = 80; next_action = 'needs-review'; _fingerprint = $fp1
+            age_days = 14; days_since_update = 2
+        }
+        $lookup = @{ '10' = $legacyEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
             -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
@@ -333,22 +340,25 @@ Describe 'Get-IncrementalPartition' {
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
-    It 'Falls back to PreviousTimestamp when _refreshed_at is absent' {
-        # entry1 has no _refreshed_at; PreviousTimestamp is recent, so reuse
-        $lookup = @{ '10' = $entry1 }
+    It 'Force-refreshes when _refreshed_at is absent (legacy entry, even with recent PreviousTimestamp)' {
+        $legacyEntry = [PSCustomObject]@{
+            number = 10; ci = 'SUCCESS'; mergeable = 'MERGEABLE'
+            score = 80; next_action = 'needs-review'; _fingerprint = $fp1
+            age_days = 14; days_since_update = 2
+        }
+        $lookup = @{ '10' = $legacyEntry }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
             -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
             -PreviousTimestamp (Get-Date).AddMinutes(-5)
-        $partition.ReusedEntries.Count | Should -Be 1
+        $partition.RefreshCandidates.Count | Should -Be 1
     }
 
     It 'Force-refreshes when _refreshed_at is malformed (non-parseable)' {
         $badEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -RefreshedAt 'not-a-date'
         $lookup = @{ '10' = $badEntry }
         $fpMap = @{ '10' = $fp1 }
-        # Malformed _refreshed_at should cause [datetime] cast to fail;
-        # fallback to PreviousTimestamp=null -> MinValue -> TTL expired -> refresh
+        # Malformed _refreshed_at should cause [datetime] cast to fail -> force refresh
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
             -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
             -PreviousTimestamp $null

--- a/scripts/Tests/IncrementalScan.Tests.ps1
+++ b/scripts/Tests/IncrementalScan.Tests.ps1
@@ -34,9 +34,10 @@ BeforeAll {
             [string]$CI = 'SUCCESS',
             [string]$Mergeable = 'MERGEABLE',
             [int]$Score = 50,
-            [string]$NextAction = 'needs-review'
+            [string]$NextAction = 'needs-review',
+            [string]$RefreshedAt = ''
         )
-        [PSCustomObject]@{
+        $entry = [PSCustomObject]@{
             number       = $Number
             ci           = $CI
             mergeable    = $Mergeable
@@ -46,6 +47,10 @@ BeforeAll {
             age_days     = 14
             days_since_update = 2
         }
+        if ($RefreshedAt) {
+            $entry | Add-Member -NotePropertyName '_refreshed_at' -NotePropertyValue $RefreshedAt
+        }
+        $entry
     }
 }
 
@@ -281,23 +286,48 @@ Describe 'Get-IncrementalPartition' {
         $partition.RefreshCandidates.Count | Should -Be 1
     }
 
-    It 'Force-refreshes all when TTL expired' {
-        $lookup = @{ '10' = $entry1; '20' = $entry2 }
+    It 'Force-refreshes when per-PR _refreshed_at exceeds TTL' {
+        $staleAt = (Get-Date).AddHours(-13).ToString("o")
+        $staleEntry1 = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -RefreshedAt $staleAt
+        $staleEntry2 = New-FakeScanEntry -Number 20 -Fingerprint $fp2 -RefreshedAt $staleAt
+        $lookup = @{ '10' = $staleEntry1; '20' = $staleEntry2 }
         $fpMap = @{ '10' = $fp1; '20' = $fp2 }
         $partition = Get-IncrementalPartition -Candidates @($pr1, $pr2) `
             -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
-            -PreviousTimestamp (Get-Date).AddHours(-13) -MaxReuseSeconds 43200
+            -PreviousTimestamp (Get-Date).AddMinutes(-5) -MaxReuseSeconds 43200
         $partition.RefreshCandidates.Count | Should -Be 2
         $partition.ReusedEntries.Count | Should -Be 0
     }
 
-    It 'Force-refreshes all when no timestamp' {
+    It 'Reuses PR with recent _refreshed_at even if scan timestamp is old' {
+        $freshAt = (Get-Date).AddMinutes(-30).ToString("o")
+        $freshEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -RefreshedAt $freshAt
+        $lookup = @{ '10' = $freshEntry }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddHours(-13) -MaxReuseSeconds 43200
+        $partition.RefreshCandidates.Count | Should -Be 0
+        $partition.ReusedEntries.Count | Should -Be 1
+    }
+
+    It 'Force-refreshes when no _refreshed_at and no PreviousTimestamp (legacy entry)' {
         $lookup = @{ '10' = $entry1 }
         $fpMap = @{ '10' = $fp1 }
         $partition = Get-IncrementalPartition -Candidates @($pr1) `
             -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
             -PreviousTimestamp $null
         $partition.RefreshCandidates.Count | Should -Be 1
+    }
+
+    It 'Falls back to PreviousTimestamp when _refreshed_at is absent' {
+        # entry1 has no _refreshed_at; PreviousTimestamp is recent, so reuse
+        $lookup = @{ '10' = $entry1 }
+        $fpMap = @{ '10' = $fp1 }
+        $partition = Get-IncrementalPartition -Candidates @($pr1) `
+            -PreviousPrLookup $lookup -PreviousFingerprints $fpMap `
+            -PreviousTimestamp (Get-Date).AddMinutes(-5)
+        $partition.ReusedEntries.Count | Should -Be 1
     }
 
     It 'Refreshes entries with missing score (corrupt cache)' {

--- a/scripts/Tests/IncrementalScan.Tests.ps1
+++ b/scripts/Tests/IncrementalScan.Tests.ps1
@@ -146,18 +146,42 @@ Describe 'Import-PreviousScan' {
         $file = "$testDir/valid.json"
         @{
             _cache_version = 2
+            repo = 'dotnet/runtime'
             timestamp = '2025-01-15T12:00:00Z'
             prs = @(
                 @{ number = 42; _fingerprint = 'fp42'; score = 50; next_action = 'review' }
                 @{ number = 99; _fingerprint = 'fp99'; score = 30; next_action = 'merge' }
             )
         } | ConvertTo-Json -Depth 5 | Set-Content $file
-        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2 -Repo 'dotnet/runtime'
         $r.Enabled | Should -BeTrue
         $r.PrLookup.Count | Should -Be 2
         $r.PrLookup['42'].score | Should -Be 50
         $r.Fingerprints['99'] | Should -Be 'fp99'
         $r.Timestamp | Should -BeOfType [DateTime]
+    }
+
+    It 'Returns disabled when repo does not match' {
+        $file = "$testDir/wrong-repo.json"
+        @{
+            _cache_version = 2
+            repo = 'dotnet/aspnetcore'
+            timestamp = '2025-01-15T12:00:00Z'
+            prs = @(@{ number = 1; _fingerprint = 'fp'; score = 10; next_action = 'x' })
+        } | ConvertTo-Json -Depth 5 | Set-Content $file
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2 -Repo 'dotnet/runtime'
+        $r.Enabled | Should -BeFalse
+    }
+
+    It 'Enables incremental when scan has no repo field (legacy scans)' {
+        $file = "$testDir/no-repo.json"
+        @{
+            _cache_version = 2
+            timestamp = '2025-01-15T12:00:00Z'
+            prs = @(@{ number = 1; _fingerprint = 'fp'; score = 10; next_action = 'x' })
+        } | ConvertTo-Json -Depth 5 | Set-Content $file
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2 -Repo 'dotnet/runtime'
+        $r.Enabled | Should -BeTrue
     }
 
     It 'Uses string keys (not Int64)' {
@@ -317,7 +341,7 @@ Describe 'Merge-ReusedEntries' {
         $merged.Count | Should -Be 1
     }
 
-    It 'Merges reused entries and recalculates time fields' {
+    It 'Preserves time fields on reused entries (score consistency)' {
         $entry = [PSCustomObject]@{
             number = 42; score = 50; _fingerprint = 'old'
             age_days = 999; days_since_update = 999
@@ -326,8 +350,10 @@ Describe 'Merge-ReusedEntries' {
         $merged = Merge-ReusedEntries -ReusedEntries @{ '42' = $entry } `
             -PrListData @($listPr) -Results @()
         $merged.Count | Should -Be 1
-        $merged[0].age_days | Should -Not -Be 999
-        $merged[0].days_since_update | Should -Not -Be 999
+        # Time fields must not be recalculated — updating them without recomputing
+        # score/next_action would create internal inconsistency in scan.json.
+        $merged[0].age_days | Should -Be 999
+        $merged[0].days_since_update | Should -Be 999
     }
 
     It 'Updates fingerprint on reused entries' {

--- a/scripts/Tests/IncrementalScan.Tests.ps1
+++ b/scripts/Tests/IncrementalScan.Tests.ps1
@@ -147,6 +147,19 @@ Describe 'Import-PreviousScan' {
         $r.Enabled | Should -BeFalse
     }
 
+    It 'Keeps incremental enabled when prs array is empty' {
+        $file = "$testDir/empty-prs.json"
+        @{
+            _cache_version = 2
+            timestamp = '2025-01-15T12:00:00Z'
+            prs = @()
+        } | ConvertTo-Json -Depth 5 | Set-Content $file
+        $r = Import-PreviousScan -Path $file -RequiredCacheVersion 2
+        $r.Enabled | Should -BeTrue
+        $r.PrLookup.Count | Should -Be 0
+        $r.Fingerprints.Count | Should -Be 0
+    }
+
     It 'Loads valid previous scan and builds lookups' {
         $file = "$testDir/valid.json"
         @{


### PR DESCRIPTION
## Summary

Adds incremental PR scanning to reduce GitHub API quota usage. Instead of fetching expensive GraphQL details for every open PR on each scan run, this compares cheap PR list data against the previous `scan.json` and only re-fetches PRs that actually changed.

Phase 1 of #54

## Expected improvements

- **~40-70% fewer GraphQL API calls per scan run**, depending on repo churn rate
- Enables scanning **more repos or more frequent refreshes** within the same quota budget
- Priority repos (runtime, aspnetcore) scanned 4x/day should see the biggest savings, since most PRs don't change between 6h scan intervals
- Currently the scan makes ~200-500 API calls per run across 12 repos; this should drop to ~60-200 for typical runs

## How it works

1. **Fingerprinting**: Each PR gets a fingerprint built from cheap list data (updatedAt, labels, mergeable, draft status, assignees, changed files count, additions, and deletions). This is free since we already fetch this data.
2. **Partitioning**: Compare current fingerprints against the previous scan. Only PRs with changed fingerprints (or non-terminal states) get the expensive GraphQL detail query.
3. **Merge**: Carried-forward entries are preserved as-is from the previous scan, including time fields (age_days, days_since_update). This is intentional ΓÇö recalculating would change triage scores without the underlying PR actually changing. The per-PR TTL (12h) bounds maximum staleness so these values are eventually refreshed.

## Fail-safe design

The prime directive is "uptime/correctness over quota savings." Every incremental code path degrades gracefully:

- Any incremental error falls back to **full scan automatically**
- Module import failure triggers **full fallback shims** for all 5 functions (with sentinel cache version 0 to ensure mismatch)
- Corrupt/missing previous `scan.json` disables incremental mode gracefully, with `Write-Warning` and `::warning::` annotation showing the reason
- **Cache version** field forces full refresh when scoring logic changes (bump `$CacheVersion`)
- **Per-PR 12h TTL** (tracked via `_refreshed_at` on each entry) bounds maximum staleness of carried-forward data
- **Non-SUCCESS CI always forces refresh** (catches reruns that don't change PR list data)
- GitHub Actions `::warning::` annotations surface any fallback events in the workflow UI

## Monitoring quota impact

After deploying, verify quota savings by checking the rate-limit summary logged at the end of each workflow run. It shows REST/GraphQL remaining vs. limit plus a delta from the start of the job. Compare before/after to gauge whether it's safe to add repos or increase refresh frequency.

## What's new

| File | Description |
|------|-------------|
| `scripts/IncrementalScan.psm1` | Extracted module with 5 testable functions |
| `scripts/Tests/IncrementalScan.Tests.ps1` | Pester tests covering fingerprinting, import, partitioning, merge, TTL |
| `scripts/Get-PrTriageData.ps1` | Uses module for incremental logic; adds `-PreviousScanFile` param |
| `.github/workflows/generate-reports.yml` | Passes previous `scan.json` path when available; rate-limit summary at job boundaries |

## Testing

- 61 Pester tests pass (24 existing Codeowners + 37 new Incremental)
- Adversarial review by rubber-duck agent caught and fixed 3 issues:
  1. Incomplete module fallback shims (was only 2 of 5 functions)
  2. Terminal CI staleness (FAILURE can change via rerun without PR fields changing)
  3. Incorrect `full_scan` metadata derivation

