### PR TITLE
Phase 3: Lightweight probe to skip unchanged repos + API quota footer

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -211,7 +211,13 @@ jobs:
                     total_used = $total_rest_used
                   } -Force
                   \$j | ConvertTo-Json -Depth 10
-                " > "docs/${slug}/scan.json.tmp" && mv "docs/${slug}/scan.json.tmp" "docs/${slug}/scan.json"
+                " > "docs/${slug}/scan.json.tmp"
+                if pwsh -Command "Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json | Out-Null"; then
+                  mv "docs/${slug}/scan.json.tmp" "docs/${slug}/scan.json"
+                else
+                  echo "::warning::_rate_limit injection produced invalid JSON for ${slug}, keeping original"
+                  rm -f "docs/${slug}/scan.json.tmp"
+                fi
               fi
             done
           fi

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -88,6 +88,7 @@ jobs:
           rate_start=$(gh api rate_limit 2>/dev/null || echo "")
           rest_start=$(echo "$rate_start" | jq -r '.resources.core.remaining // empty' 2>/dev/null || echo "")
           graphql_start=$(echo "$rate_start" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || echo "")
+          scanned_slugs=()  # Track repos that were actually scanned or probed this run
           for entry in "${repos[@]}"; do
             IFS=':' read -r repo slug tier <<< "$entry"
 
@@ -121,6 +122,7 @@ jobs:
               scan_needed=$(pwsh ./scripts/Test-ScanNeeded.ps1 -Repo "$repo" -PreviousScanFile "docs/${slug}/scan.json" 2>/dev/null || echo "true")
               if [ "$scan_needed" = "false" ]; then
                 echo "::notice::${repo} — probe says unchanged, skipping scan"
+                scanned_slugs+=("$slug")
                 # Still run Build-Reports in case templates changed
                 if ! pwsh ./scripts/Build-Reports.ps1 -ScanFile "docs/${slug}/scan.json" -Repo "$repo" -Slug "$slug" -ScheduleDesc "$schedule_desc" -SkipAI; then
                   echo "::warning::Report generation failed for $repo"
@@ -161,6 +163,7 @@ jobs:
               failed+=("$repo")
               continue
             fi
+            scanned_slugs+=("$slug")
           done
           # Log total API quota consumed across all repos (2 calls total, not per-repo)
           rate_end=$(gh api rate_limit 2>/dev/null || echo "")
@@ -181,14 +184,13 @@ jobs:
           if [ -n "$quota_summary" ]; then
             echo "::notice::Total API usage — ${quota_summary}"
           fi
-          # Inject rate-limit snapshot into each scan.json for footer display (0 extra API calls)
+          # Inject rate-limit snapshot into scan.json for repos processed this run (0 extra API calls)
           if [ -n "$rest_end" ] || [ -n "$graphql_end" ]; then
             rate_reset=$(echo "$rate_end" | jq -r '.resources.core.reset // empty' 2>/dev/null || echo "")
             total_rest_used=0
             [ -n "$rest_start" ] && [ -n "$rest_end" ] && total_rest_used=$((rest_start - rest_end))
             [ "$total_rest_used" -lt 0 ] && total_rest_used=0
-            for entry in "${repos[@]}"; do
-              IFS=':' read -r repo slug tier <<< "$entry"
+            for slug in "${scanned_slugs[@]}"; do
               if [ -f "docs/${slug}/scan.json" ]; then
                 pwsh -Command "
                   \$j = Get-Content 'docs/${slug}/scan.json' -Raw | ConvertFrom-Json

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -157,14 +157,21 @@ jobs:
               echo "::notice::${repo} ${incremental_info}"
             fi
             # Validate the output is parseable JSON with a prs array
-            if $scan_ok && pwsh -Command "(\$j = Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json) -and \$j.prs -ne \$null" > /dev/null 2>&1; then
+            # Note: pwsh -Command "expr" always exits 0 regardless of expr's boolean value;
+            # only exceptions cause non-zero exit. Use explicit exit 0/1 for reliable checks.
+            if $scan_ok && pwsh -NoProfile -Command "
+              try {
+                \$j = Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json
+                if (\$null -ne \$j.prs) { exit 0 } else { Write-Host 'No prs property found'; exit 1 }
+              } catch { Write-Host \"Parse error: \$_\"; exit 1 }
+            "; then
               mv "docs/${slug}/scan.json.tmp" "docs/${slug}/scan.json"
             else
               echo "::warning::Invalid or empty scan output for $repo — keeping previous data"
               rm -f "docs/${slug}/scan.json.tmp"
+              failed+=("$repo")
               if [ ! -f "docs/${slug}/scan.json" ]; then
                 echo "::warning::No previous scan.json for $repo — skipping reports"
-                failed+=("$repo")
                 continue
               fi
             fi

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -219,7 +219,7 @@ jobs:
                   } -Force
                   \$j | ConvertTo-Json -Depth 10
                 " > "docs/${slug}/scan.json.tmp"
-                if pwsh -Command "Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json | Out-Null"; then
+                if pwsh -NoProfile -Command "try { Get-Content 'docs/${slug}/scan.json.tmp' -Raw | ConvertFrom-Json | Out-Null; exit 0 } catch { exit 1 }"; then
                   mv "docs/${slug}/scan.json.tmp" "docs/${slug}/scan.json"
                 else
                   echo "::warning::_rate_limit injection produced invalid JSON for ${slug}, keeping original"

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -118,8 +118,12 @@ jobs:
             if [ -f "docs/${slug}/scan.json" ]; then
               prev_scan_args="-PreviousScanFile docs/${slug}/scan.json"
 
-              # Lightweight probe: skip scan entirely if nothing changed and previous scan is stable
-              # MaxSkipSeconds must exceed the longest schedule interval for this tier
+              # Lightweight probe: skip scan entirely if nothing changed and previous scan is stable.
+              # MaxSkipSeconds exceeds the longest schedule interval for this tier so that the probe
+              # age check doesn't prevent skipping on the very next run after a scan. Tradeoff: a
+              # quiet repo can stay unscanned for up to one extra run interval beyond max_skip before
+              # the age check forces a rescan. This staleness is acceptable because the probe also
+              # checks for unstable PRs and only skips when the PR set is provably unchanged.
               if [ "$tier" = "priority" ]; then
                 max_skip=46800   # 13h (priority runs every ~6h weekdays, ~12h weekends)
               else

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -164,12 +164,12 @@ jobs:
                 continue
               fi
             fi
+            scanned_slugs+=("$slug")
             if ! pwsh ./scripts/Build-Reports.ps1 -ScanFile "docs/${slug}/scan.json" -Repo "$repo" -Slug "$slug" -ScheduleDesc "$schedule_desc" -SkipAI; then
               echo "::warning::Report generation failed for $repo"
               failed+=("$repo")
               continue
             fi
-            scanned_slugs+=("$slug")
           done
           # Log total API quota consumed across all repos (2 calls total, not per-repo)
           rate_end=$(gh api rate_limit 2>/dev/null || echo "")

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -116,6 +116,18 @@ jobs:
             prev_scan_args=""
             if [ -f "docs/${slug}/scan.json" ]; then
               prev_scan_args="-PreviousScanFile docs/${slug}/scan.json"
+
+              # Lightweight probe: skip scan entirely if nothing changed and previous scan is stable
+              scan_needed=$(pwsh ./scripts/Test-ScanNeeded.ps1 -Repo "$repo" -PreviousScanFile "docs/${slug}/scan.json" 2>/dev/null || echo "true")
+              if [ "$scan_needed" = "false" ]; then
+                echo "::notice::${repo} — probe says unchanged, skipping scan"
+                # Still run Build-Reports in case templates changed
+                if ! pwsh ./scripts/Build-Reports.ps1 -ScanFile "docs/${slug}/scan.json" -Repo "$repo" -Slug "$slug" -ScheduleDesc "$schedule_desc" -SkipAI; then
+                  echo "::warning::Report generation failed for $repo"
+                  failed+=("$repo")
+                fi
+                continue
+              fi
             fi
             # Write scan to temp file; only overwrite scan.json if valid JSON
             scan_ok=true
@@ -168,6 +180,28 @@ jobs:
           fi
           if [ -n "$quota_summary" ]; then
             echo "::notice::Total API usage — ${quota_summary}"
+          fi
+          # Inject rate-limit snapshot into each scan.json for footer display (0 extra API calls)
+          if [ -n "$rest_end" ] || [ -n "$graphql_end" ]; then
+            rate_reset=$(echo "$rate_end" | jq -r '.resources.core.reset // empty' 2>/dev/null || echo "")
+            total_rest_used=0
+            [ -n "$rest_start" ] && [ -n "$rest_end" ] && total_rest_used=$((rest_start - rest_end))
+            [ "$total_rest_used" -lt 0 ] && total_rest_used=0
+            for entry in "${repos[@]}"; do
+              IFS=':' read -r repo slug tier <<< "$entry"
+              if [ -f "docs/${slug}/scan.json" ]; then
+                pwsh -Command "
+                  \$j = Get-Content 'docs/${slug}/scan.json' -Raw | ConvertFrom-Json
+                  \$j | Add-Member -NotePropertyName '_rate_limit' -NotePropertyValue @{
+                    rest_remaining = ${rest_end:-0}
+                    graphql_remaining = ${graphql_end:-0}
+                    reset = ${rate_reset:-0}
+                    total_used = $total_rest_used
+                  } -Force
+                  \$j | ConvertTo-Json -Depth 10
+                " > "docs/${slug}/scan.json.tmp" && mv "docs/${slug}/scan.json.tmp" "docs/${slug}/scan.json"
+              fi
+            done
           fi
           if [ ${#failed[@]} -gt 0 ]; then
             echo "::warning::Failed repos: ${failed[*]}"

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -88,7 +88,8 @@ jobs:
           rate_start=$(gh api rate_limit 2>/dev/null || echo "")
           rest_start=$(echo "$rate_start" | jq -r '.resources.core.remaining // empty' 2>/dev/null || echo "")
           graphql_start=$(echo "$rate_start" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null || echo "")
-          scanned_slugs=()  # Track repos that were actually scanned or probed this run
+          scanned_slugs=()  # Track repos that were processed this run (scanned or probe-skipped)
+          freshly_scanned=()  # Track repos that were actually rescanned (for rate-limit injection)
           for entry in "${repos[@]}"; do
             IFS=':' read -r repo slug tier <<< "$entry"
 
@@ -176,6 +177,7 @@ jobs:
               fi
             fi
             scanned_slugs+=("$slug")
+            freshly_scanned+=("$slug")
             if ! pwsh ./scripts/Build-Reports.ps1 -ScanFile "docs/${slug}/scan.json" -Repo "$repo" -Slug "$slug" -ScheduleDesc "$schedule_desc" -SkipAI; then
               echo "::warning::Report generation failed for $repo"
               failed+=("$repo")
@@ -207,7 +209,7 @@ jobs:
             total_rest_used=0
             [ -n "$rest_start" ] && [ -n "$rest_end" ] && total_rest_used=$((rest_start - rest_end))
             [ "$total_rest_used" -lt 0 ] && total_rest_used=0
-            for slug in "${scanned_slugs[@]}"; do
+            for slug in "${freshly_scanned[@]}"; do
               if [ -f "docs/${slug}/scan.json" ]; then
                 pwsh -Command "
                   \$j = Get-Content 'docs/${slug}/scan.json' -Raw | ConvertFrom-Json

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -119,7 +119,13 @@ jobs:
               prev_scan_args="-PreviousScanFile docs/${slug}/scan.json"
 
               # Lightweight probe: skip scan entirely if nothing changed and previous scan is stable
-              scan_needed=$(pwsh ./scripts/Test-ScanNeeded.ps1 -Repo "$repo" -PreviousScanFile "docs/${slug}/scan.json" 2>/dev/null || echo "true")
+              # MaxSkipSeconds must exceed the longest schedule interval for this tier
+              if [ "$tier" = "priority" ]; then
+                max_skip=46800   # 13h (priority runs every ~6h weekdays, ~12h weekends)
+              else
+                max_skip=90000   # 25h (standard runs ~daily)
+              fi
+              scan_needed=$(pwsh ./scripts/Test-ScanNeeded.ps1 -Repo "$repo" -PreviousScanFile "docs/${slug}/scan.json" -MaxSkipSeconds $max_skip 2>/dev/null || echo "true")
               if [ "$scan_needed" = "false" ]; then
                 echo "::notice::${repo} — probe says unchanged, skipping scan"
                 scanned_slugs+=("$slug")

--- a/docs/all/actionable.html
+++ b/docs/all/actionable.html
@@ -425,8 +425,24 @@
         }
 
         // Show API rate limit in footer (subtle, for admins)
-        var rateLimits = results
-          .filter(function(r) { return r._rate_limit; })
+        // Only use _rate_limit from the most recent scan run to avoid mixing stale data
+        // Use 1h tolerance since repos in the same run finish within minutes of each other
+        var rateLimitResults = results.filter(function(r) { return r._rate_limit; });
+        var newestUpdatedMs = null;
+        rateLimitResults.forEach(function(r) {
+          if (!r.updated) return;
+          var ms = new Date(r.updated).getTime();
+          if (!isNaN(ms) && (newestUpdatedMs === null || ms > newestUpdatedMs)) newestUpdatedMs = ms;
+        });
+        if (newestUpdatedMs !== null) {
+          var ONE_HOUR_MS = 3600000;
+          rateLimitResults = rateLimitResults.filter(function(r) {
+            if (!r.updated) return false;
+            var ms = new Date(r.updated).getTime();
+            return !isNaN(ms) && (newestUpdatedMs - ms) < ONE_HOUR_MS;
+          });
+        }
+        var rateLimits = rateLimitResults
           .map(function(r) { return { repo: r.repo, rest_remaining: r._rate_limit.rest_remaining, graphql_remaining: r._rate_limit.graphql_remaining, reset: r._rate_limit.reset, total_used: r._rate_limit.total_used }; });
         if (window.showRateLimit) window.showRateLimit(rateLimits);
 

--- a/docs/all/actionable.html
+++ b/docs/all/actionable.html
@@ -385,7 +385,7 @@
               pr._slug = slug;
               pr._repo = repoName;
             });
-            return { slug: slug, repo: repoName, prs: data.prs || [], updated: meta.updated || null, schedule_desc: meta.schedule_desc || null };
+            return { slug: slug, repo: repoName, prs: data.prs || [], updated: meta.updated || null, schedule_desc: meta.schedule_desc || null, _rate_limit: data._rate_limit || null };
           });
         });
         return Promise.all(fetches);
@@ -423,6 +423,12 @@
           // Expose oldest scan timestamp so pr-view-refresh.js can filter new-PR discovery
           document.getElementById('meta-line').setAttribute('data-server-updated', timestamps[0].toISOString());
         }
+
+        // Show API rate limit in footer (subtle, for admins)
+        var rateLimits = results
+          .filter(function(r) { return r._rate_limit; })
+          .map(function(r) { return { repo: r.repo, rest_remaining: r._rate_limit.rest_remaining, graphql_remaining: r._rate_limit.graphql_remaining, reset: r._rate_limit.reset, used_this_repo: r._rate_limit.used_this_repo }; });
+        if (window.showRateLimit) window.showRateLimit(rateLimits);
 
         if (activeUsers.length > 0) {
           renderFiltered(activeUsers);

--- a/docs/all/actionable.html
+++ b/docs/all/actionable.html
@@ -427,7 +427,7 @@
         // Show API rate limit in footer (subtle, for admins)
         var rateLimits = results
           .filter(function(r) { return r._rate_limit; })
-          .map(function(r) { return { repo: r.repo, rest_remaining: r._rate_limit.rest_remaining, graphql_remaining: r._rate_limit.graphql_remaining, reset: r._rate_limit.reset, used_this_repo: r._rate_limit.used_this_repo }; });
+          .map(function(r) { return { repo: r.repo, rest_remaining: r._rate_limit.rest_remaining, graphql_remaining: r._rate_limit.graphql_remaining, reset: r._rate_limit.reset, total_used: r._rate_limit.total_used }; });
         if (window.showRateLimit) window.showRateLimit(rateLimits);
 
         if (activeUsers.length > 0) {

--- a/docs/footer.js
+++ b/docs/footer.js
@@ -35,14 +35,18 @@
     });
     if (minRestRemaining === Infinity && minGraphqlRemaining === Infinity) return;
     var resetDate = new Date(resetEpoch * 1000);
-    var resetStr = resetDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    var hasValidReset = resetEpoch > 0 && !isNaN(resetDate.getTime());
+    var resetStr = hasValidReset ? resetDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
     var parts = [];
     if (minRestRemaining !== Infinity) parts.push('REST ' + minRestRemaining);
     if (minGraphqlRemaining !== Infinity) parts.push('GraphQL ' + minGraphqlRemaining);
     var span = document.createElement('span');
     span.style.cssText = 'margin-left:1.5em;opacity:0.6;';
-    span.title = 'GitHub API quota remaining after last pipeline run. Resets at ' + resetStr + '.';
-    span.textContent = 'API: ' + parts.join(', ') + ' remaining (used ~' + totalUsed + ' REST, resets ' + resetStr + ')';
+    span.title = hasValidReset
+      ? 'GitHub API quota remaining after last pipeline run. Resets at ' + resetStr + '.'
+      : 'GitHub API quota remaining after last pipeline run.';
+    span.textContent = 'API: ' + parts.join(', ') + ' remaining (used ~' + totalUsed + ' REST' +
+      (hasValidReset ? ', resets ' + resetStr : '') + ')';
     footer.appendChild(span);
   };
 })();

--- a/docs/footer.js
+++ b/docs/footer.js
@@ -18,4 +18,31 @@
     '<img src="https://github.com/danmoseley/pr-dashboard/actions/workflows/generate-reports.yml/badge.svg" alt="Pipeline status" style="height:20px;vertical-align:middle"></a>';
 
   document.body.appendChild(footer);
+
+  // Expose helper so pages can show API rate-limit info once scan data is loaded.
+  // rateLimits: array of { repo, remaining, reset, used_this_repo }
+  window.showRateLimit = function (rateLimits) {
+    if (!rateLimits || rateLimits.length === 0) return;
+    var minRestRemaining = Infinity;
+    var minGraphqlRemaining = Infinity;
+    var resetEpoch = 0;
+    var totalUsed = 0;
+    rateLimits.forEach(function (rl) {
+      if (rl.rest_remaining != null && rl.rest_remaining < minRestRemaining) minRestRemaining = rl.rest_remaining;
+      if (rl.graphql_remaining != null && rl.graphql_remaining < minGraphqlRemaining) minGraphqlRemaining = rl.graphql_remaining;
+      if (rl.reset && rl.reset > resetEpoch) resetEpoch = rl.reset;
+      if (rl.used_this_repo) totalUsed += rl.used_this_repo;
+    });
+    if (minRestRemaining === Infinity && minGraphqlRemaining === Infinity) return;
+    var resetDate = new Date(resetEpoch * 1000);
+    var resetStr = resetDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    var parts = [];
+    if (minRestRemaining !== Infinity) parts.push('REST ' + minRestRemaining);
+    if (minGraphqlRemaining !== Infinity) parts.push('GraphQL ' + minGraphqlRemaining);
+    var span = document.createElement('span');
+    span.style.cssText = 'margin-left:1.5em;opacity:0.6;';
+    span.title = 'GitHub API quota remaining after last pipeline run. Resets at ' + resetStr + '.';
+    span.textContent = 'API: ' + parts.join(', ') + ' remaining (used ~' + totalUsed + ' REST, resets ' + resetStr + ')';
+    footer.appendChild(span);
+  };
 })();

--- a/docs/footer.js
+++ b/docs/footer.js
@@ -20,7 +20,7 @@
   document.body.appendChild(footer);
 
   // Expose helper so pages can show API rate-limit info once scan data is loaded.
-  // rateLimits: array of { repo, remaining, reset, used_this_repo }
+  // rateLimits: array of { rest_remaining, graphql_remaining, reset, total_used }
   window.showRateLimit = function (rateLimits) {
     if (!rateLimits || rateLimits.length === 0) return;
     var minRestRemaining = Infinity;
@@ -31,7 +31,7 @@
       if (rl.rest_remaining != null && rl.rest_remaining < minRestRemaining) minRestRemaining = rl.rest_remaining;
       if (rl.graphql_remaining != null && rl.graphql_remaining < minGraphqlRemaining) minGraphqlRemaining = rl.graphql_remaining;
       if (rl.reset && rl.reset > resetEpoch) resetEpoch = rl.reset;
-      if (rl.used_this_repo) totalUsed += rl.used_this_repo;
+      if (rl.total_used != null && rl.total_used > totalUsed) totalUsed = rl.total_used;
     });
     if (minRestRemaining === Infinity && minGraphqlRemaining === Infinity) return;
     var resetDate = new Date(resetEpoch * 1000);

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -76,6 +76,19 @@ try {
 }
 $CacheVersion = Get-IncrementalCacheVersion
 
+# Compute a lightweight probe hash from PR numbers + updatedAt timestamps.
+# Used by Test-ScanNeeded.ps1 to skip unchanged repos without a full scan.
+# Must stay in sync with the hash logic in Test-ScanNeeded.ps1.
+function Get-ProbeHash([array]$PrListData) {
+    $pairs = @($PrListData | ForEach-Object {
+        $ts = if ($_.updatedAt -is [datetime]) { $_.updatedAt.ToUniversalTime().ToString('o') } else { "$($_.updatedAt)" }
+        "$($_.number):$ts"
+    } | Sort-Object)
+    $input = "total=$($PrListData.Count)|" + ($pairs -join '|')
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    [BitConverter]::ToString($sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($input))).Replace('-', '').Substring(0, 16).ToLower()
+}
+
 # Retry wrapper for gh CLI calls (handles transient HTTP 5xx / 429 errors)
 function Invoke-GhRetry {
     param([string[]]$Arguments, [int]$MaxAttempts = 4, [int[]]$DelaySeconds = @(60, 300, 1200))
@@ -276,14 +289,6 @@ Write-Verbose "Scanned $($prsRaw.Count) -> $($candidates.Count) candidates ($exc
 
 if ($candidates.Count -eq 0) {
     Write-Verbose "No candidates to analyze."
-    # Compute probe hash even for empty results
-    $probePairs = @($prsRaw | ForEach-Object {
-        $ts = if ($_.updatedAt -is [datetime]) { $_.updatedAt.ToUniversalTime().ToString('o') } else { "$($_.updatedAt)" }
-        "$($_.number):$ts"
-    } | Sort-Object)
-    $probeInput = "total=$($prsRaw.Count)|" + ($probePairs -join '|')
-    $sha0 = [System.Security.Cryptography.SHA256]::Create()
-    $probeHash0 = [BitConverter]::ToString($sha0.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($probeInput))).Replace('-', '').Substring(0, 16).ToLower()
     @{
         repo = $Repo
         timestamp = $now.ToString("o")
@@ -291,7 +296,7 @@ if ($candidates.Count -eq 0) {
         analyzed = 0
         prs = @()
         _cache_version = $CacheVersion
-        _probe_hash = $probeHash0
+        _probe_hash = (Get-ProbeHash $prsRaw)
     } | ConvertTo-Json -Depth 5
     return
 }
@@ -1127,15 +1132,7 @@ if ($Top -gt 0) {
 }
 
 # --- Output JSON ---
-# Compute probe hash for lightweight skip-scan detection (matches Test-ScanNeeded.ps1)
-$probePairs = @($prsRaw | ForEach-Object {
-    $ts = if ($_.updatedAt -is [datetime]) { $_.updatedAt.ToUniversalTime().ToString('o') } else { "$($_.updatedAt)" }
-    "$($_.number):$ts"
-} | Sort-Object)
-$probeInput = "total=$($prsRaw.Count)|" + ($probePairs -join '|')
-$sha = [System.Security.Cryptography.SHA256]::Create()
-$probeBytes = [System.Text.Encoding]::UTF8.GetBytes($probeInput)
-$probeHash = [BitConverter]::ToString($sha.ComputeHash($probeBytes)).Replace('-', '').Substring(0, 16).ToLower()
+$probeHash = Get-ProbeHash $prsRaw
 
 $output = @{
     timestamp = $now.ToString("o")

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -276,6 +276,11 @@ Write-Verbose "Scanned $($prsRaw.Count) -> $($candidates.Count) candidates ($exc
 
 if ($candidates.Count -eq 0) {
     Write-Verbose "No candidates to analyze."
+    # Compute probe hash even for empty results
+    $probePairs = @($prsRaw | ForEach-Object { "$($_.number):$($_.updatedAt)" } | Sort-Object)
+    $probeInput = "total=$($prsRaw.Count)|" + ($probePairs -join '|')
+    $sha0 = [System.Security.Cryptography.SHA256]::Create()
+    $probeHash0 = [BitConverter]::ToString($sha0.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($probeInput))).Replace('-', '').Substring(0, 16).ToLower()
     @{
         repo = $Repo
         timestamp = $now.ToString("o")
@@ -283,6 +288,7 @@ if ($candidates.Count -eq 0) {
         analyzed = 0
         prs = @()
         _cache_version = $CacheVersion
+        _probe_hash = $probeHash0
     } | ConvertTo-Json -Depth 5
     return
 }
@@ -1118,9 +1124,17 @@ if ($Top -gt 0) {
 }
 
 # --- Output JSON ---
+# Compute probe hash for lightweight skip-scan detection (matches Test-ScanNeeded.ps1)
+$probePairs = @($prsRaw | ForEach-Object { "$($_.number):$($_.updatedAt)" } | Sort-Object)
+$probeInput = "total=$($prsRaw.Count)|" + ($probePairs -join '|')
+$sha = [System.Security.Cryptography.SHA256]::Create()
+$probeBytes = [System.Text.Encoding]::UTF8.GetBytes($probeInput)
+$probeHash = [BitConverter]::ToString($sha.ComputeHash($probeBytes)).Replace('-', '').Substring(0, 16).ToLower()
+
 $output = @{
     timestamp = $now.ToString("o")
     repo = $Repo
+    _probe_hash = $probeHash
     filters = @{
         label = if ($Label) { $Label } else { $null }
         author = if ($Author) { $Author } else { $null }

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -277,7 +277,10 @@ Write-Verbose "Scanned $($prsRaw.Count) -> $($candidates.Count) candidates ($exc
 if ($candidates.Count -eq 0) {
     Write-Verbose "No candidates to analyze."
     # Compute probe hash even for empty results
-    $probePairs = @($prsRaw | ForEach-Object { "$($_.number):$($_.updatedAt)" } | Sort-Object)
+    $probePairs = @($prsRaw | ForEach-Object {
+        $ts = if ($_.updatedAt -is [datetime]) { $_.updatedAt.ToUniversalTime().ToString('o') } else { "$($_.updatedAt)" }
+        "$($_.number):$ts"
+    } | Sort-Object)
     $probeInput = "total=$($prsRaw.Count)|" + ($probePairs -join '|')
     $sha0 = [System.Security.Cryptography.SHA256]::Create()
     $probeHash0 = [BitConverter]::ToString($sha0.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($probeInput))).Replace('-', '').Substring(0, 16).ToLower()
@@ -1125,7 +1128,10 @@ if ($Top -gt 0) {
 
 # --- Output JSON ---
 # Compute probe hash for lightweight skip-scan detection (matches Test-ScanNeeded.ps1)
-$probePairs = @($prsRaw | ForEach-Object { "$($_.number):$($_.updatedAt)" } | Sort-Object)
+$probePairs = @($prsRaw | ForEach-Object {
+    $ts = if ($_.updatedAt -is [datetime]) { $_.updatedAt.ToUniversalTime().ToString('o') } else { "$($_.updatedAt)" }
+    "$($_.number):$ts"
+} | Sort-Object)
 $probeInput = "total=$($prsRaw.Count)|" + ($probePairs -join '|')
 $sha = [System.Security.Cryptography.SHA256]::Create()
 $probeBytes = [System.Text.Encoding]::UTF8.GetBytes($probeInput)

--- a/scripts/Test-ScanNeeded.ps1
+++ b/scripts/Test-ScanNeeded.ps1
@@ -1,0 +1,110 @@
+<#
+.SYNOPSIS
+    Lightweight probe to check whether a full/incremental scan is needed for a repo.
+    Makes a single cheap GraphQL query and compares against the previous scan.
+.DESCRIPTION
+    Returns "true" (scan needed) or "false" (safe to skip).
+    Fail-safe: any error returns "true" (always scan when in doubt).
+.PARAMETER Repo
+    Repository in owner/repo format.
+.PARAMETER PreviousScanFile
+    Path to the previous scan.json for this repo.
+.PARAMETER MaxSkipSeconds
+    Maximum age of previous scan before forcing a rescan regardless of probe result.
+    Default: 10800 (3 hours). Should be well under the incremental TTL (12h).
+#>
+param(
+    [Parameter(Mandatory)][string]$Repo,
+    [Parameter(Mandatory)][string]$PreviousScanFile,
+    [int]$MaxSkipSeconds = 10800
+)
+
+# Fail-safe wrapper: any unhandled error → scan needed
+try {
+    if (-not (Test-Path $PreviousScanFile)) {
+        Write-Host "true"  # No previous scan — must scan
+        exit 0
+    }
+
+    $prevScan = Get-Content $PreviousScanFile -Raw | ConvertFrom-Json
+
+    # Check previous scan timestamp — don't skip if too old
+    if ($prevScan.timestamp) {
+        $age = ((Get-Date) - [DateTime]::Parse($prevScan.timestamp)).TotalSeconds
+        if ($age -gt $MaxSkipSeconds) {
+            Write-Verbose "Previous scan is $([int]($age/60))m old (max $([int]($MaxSkipSeconds/60))m) — scan needed"
+            Write-Host "true"
+            exit 0
+        }
+    } else {
+        Write-Host "true"  # No timestamp — must scan
+        exit 0
+    }
+
+    # Check for unstable PRs in previous scan — don't skip if any exist
+    if ($prevScan.prs) {
+        $unstable = @($prevScan.prs | Where-Object {
+            ($_.ci -and $_.ci -ne 'SUCCESS') -or
+            ($_.mergeable -and $_.mergeable -eq 'UNKNOWN')
+        })
+        if ($unstable.Count -gt 0) {
+            Write-Verbose "$($unstable.Count) unstable PRs in previous scan — scan needed"
+            Write-Host "true"
+            exit 0
+        }
+    }
+
+    # Check for previous probe hash
+    if (-not $prevScan._probe_hash) {
+        Write-Host "true"  # No probe hash stored — must scan
+        exit 0
+    }
+
+    # Cheap GraphQL query: get open PR numbers + updatedAt
+    $owner, $name = $Repo -split '/', 2
+    $query = @"
+query {
+  repository(owner: "$owner", name: "$name") {
+    pullRequests(states: OPEN, first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      totalCount
+      nodes { number updatedAt }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+"@
+    $result = gh api graphql -f query="$query" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Verbose "GraphQL probe failed — scan needed"
+        Write-Host "true"
+        exit 0
+    }
+    $data = $result | ConvertFrom-Json
+    $prData = $data.data.repository.pullRequests
+
+    # If more than 100 open PRs, probe hash can't match full scan hash — must scan
+    if ($prData.pageInfo.hasNextPage) {
+        Write-Verbose "More than 100 open PRs ($($prData.totalCount)) — scan needed"
+        Write-Host "true"
+        exit 0
+    }
+
+    $pairs = @($prData.nodes | ForEach-Object { "$($_.number):$($_.updatedAt)" } | Sort-Object)
+    $hashInput = "total=$($prData.totalCount)|" + ($pairs -join '|')
+
+    # Hash the probe data
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($hashInput)
+    $probeHash = [BitConverter]::ToString($sha.ComputeHash($bytes)).Replace('-', '').Substring(0, 16).ToLower()
+
+    if ($probeHash -eq $prevScan._probe_hash) {
+        Write-Verbose "Probe hash unchanged ($probeHash) — skip scan"
+        Write-Host "false"
+    } else {
+        Write-Verbose "Probe hash changed (was $($prevScan._probe_hash), now $probeHash) — scan needed"
+        Write-Host "true"
+    }
+} catch {
+    Write-Verbose "Probe error: $_ — scan needed (fail-safe)"
+    Write-Host "true"
+}

--- a/scripts/Test-ScanNeeded.ps1
+++ b/scripts/Test-ScanNeeded.ps1
@@ -14,6 +14,7 @@
     Default: 10800 (3 hours). Callers may increase this to match workflow cadence
     and the maximum freshness window they are willing to tolerate.
 #>
+[CmdletBinding()]
 param(
     [Parameter(Mandatory)][string]$Repo,
     [Parameter(Mandatory)][string]$PreviousScanFile,

--- a/scripts/Test-ScanNeeded.ps1
+++ b/scripts/Test-ScanNeeded.ps1
@@ -73,13 +73,25 @@ query {
   }
 }
 "@
-    $result = gh api graphql -f query="$query" 2>&1
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $result = gh api graphql -f query="$query" 2> $stderrFile
+        $stderr = if (Test-Path $stderrFile) { Get-Content -Raw -Path $stderrFile } else { '' }
+    } finally {
+        if (Test-Path $stderrFile) { Remove-Item -Path $stderrFile -Force -ErrorAction SilentlyContinue }
+    }
     if ($LASTEXITCODE -ne 0) {
-        Write-Verbose "GraphQL probe failed — scan needed"
+        Write-Verbose "GraphQL probe failed: $stderr — scan needed"
         Write-Host "true"
         exit 0
     }
-    $data = $result | ConvertFrom-Json
+    $resultJson = ($result -join "`n")
+    if ([string]::IsNullOrWhiteSpace($resultJson)) {
+        Write-Verbose "GraphQL probe returned empty output — scan needed"
+        Write-Host "true"
+        exit 0
+    }
+    $data = $resultJson | ConvertFrom-Json
     $prData = $data.data.repository.pullRequests
 
     # If more than 100 open PRs, probe hash can't match full scan hash — must scan

--- a/scripts/Test-ScanNeeded.ps1
+++ b/scripts/Test-ScanNeeded.ps1
@@ -22,7 +22,7 @@ param(
 # Fail-safe wrapper: any unhandled error → scan needed
 try {
     if (-not (Test-Path $PreviousScanFile)) {
-        Write-Host "true"  # No previous scan — must scan
+        Write-Output "true"  # No previous scan — must scan
         exit 0
     }
 
@@ -33,11 +33,11 @@ try {
         $age = ((Get-Date) - [DateTime]::Parse($prevScan.timestamp)).TotalSeconds
         if ($age -gt $MaxSkipSeconds) {
             Write-Verbose "Previous scan is $([int]($age/60))m old (max $([int]($MaxSkipSeconds/60))m) — scan needed"
-            Write-Host "true"
+            Write-Output "true"
             exit 0
         }
     } else {
-        Write-Host "true"  # No timestamp — must scan
+        Write-Output "true"  # No timestamp — must scan
         exit 0
     }
 
@@ -49,14 +49,14 @@ try {
         })
         if ($unstable.Count -gt 0) {
             Write-Verbose "$($unstable.Count) unstable PRs in previous scan — scan needed"
-            Write-Host "true"
+            Write-Output "true"
             exit 0
         }
     }
 
     # Check for previous probe hash
     if (-not $prevScan._probe_hash) {
-        Write-Host "true"  # No probe hash stored — must scan
+        Write-Output "true"  # No probe hash stored — must scan
         exit 0
     }
 
@@ -82,13 +82,13 @@ query {
     }
     if ($LASTEXITCODE -ne 0) {
         Write-Verbose "GraphQL probe failed: $stderr — scan needed"
-        Write-Host "true"
+        Write-Output "true"
         exit 0
     }
     $resultJson = ($result -join "`n")
     if ([string]::IsNullOrWhiteSpace($resultJson)) {
         Write-Verbose "GraphQL probe returned empty output — scan needed"
-        Write-Host "true"
+        Write-Output "true"
         exit 0
     }
     $data = $resultJson | ConvertFrom-Json
@@ -97,7 +97,7 @@ query {
     # If more than 100 open PRs, probe hash can't match full scan hash — must scan
     if ($prData.pageInfo.hasNextPage) {
         Write-Verbose "More than 100 open PRs ($($prData.totalCount)) — scan needed"
-        Write-Host "true"
+        Write-Output "true"
         exit 0
     }
 
@@ -115,12 +115,12 @@ query {
 
     if ($probeHash -eq $prevScan._probe_hash) {
         Write-Verbose "Probe hash unchanged ($probeHash) — skip scan"
-        Write-Host "false"
+        Write-Output "false"
     } else {
         Write-Verbose "Probe hash changed (was $($prevScan._probe_hash), now $probeHash) — scan needed"
-        Write-Host "true"
+        Write-Output "true"
     }
 } catch {
     Write-Verbose "Probe error: $_ — scan needed (fail-safe)"
-    Write-Host "true"
+    Write-Output "true"
 }

--- a/scripts/Test-ScanNeeded.ps1
+++ b/scripts/Test-ScanNeeded.ps1
@@ -31,7 +31,18 @@ try {
 
     # Check previous scan timestamp — don't skip if too old
     if ($prevScan.timestamp) {
-        $age = ((Get-Date) - [DateTime]::Parse($prevScan.timestamp)).TotalSeconds
+        $prevTimestamp = if ($prevScan.timestamp -is [System.DateTimeOffset]) {
+            $prevScan.timestamp
+        } elseif ($prevScan.timestamp -is [System.DateTime]) {
+            [System.DateTimeOffset]$prevScan.timestamp
+        } else {
+            [System.DateTimeOffset]::Parse(
+                [string]$prevScan.timestamp,
+                [System.Globalization.CultureInfo]::InvariantCulture,
+                [System.Globalization.DateTimeStyles]::RoundtripKind
+            )
+        }
+        $age = ([System.DateTimeOffset]::UtcNow - $prevTimestamp.ToUniversalTime()).TotalSeconds
         if ($age -gt $MaxSkipSeconds) {
             Write-Verbose "Previous scan is $([int]($age/60))m old (max $([int]($MaxSkipSeconds/60))m) — scan needed"
             Write-Output "true"

--- a/scripts/Test-ScanNeeded.ps1
+++ b/scripts/Test-ScanNeeded.ps1
@@ -11,7 +11,8 @@
     Path to the previous scan.json for this repo.
 .PARAMETER MaxSkipSeconds
     Maximum age of previous scan before forcing a rescan regardless of probe result.
-    Default: 10800 (3 hours). Should be well under the incremental TTL (12h).
+    Default: 10800 (3 hours). Callers may increase this to match workflow cadence
+    and the maximum freshness window they are willing to tolerate.
 #>
 param(
     [Parameter(Mandatory)][string]$Repo,

--- a/scripts/Test-ScanNeeded.ps1
+++ b/scripts/Test-ScanNeeded.ps1
@@ -89,7 +89,11 @@ query {
         exit 0
     }
 
-    $pairs = @($prData.nodes | ForEach-Object { "$($_.number):$($_.updatedAt)" } | Sort-Object)
+    $pairs = @($prData.nodes | ForEach-Object {
+        # Canonicalize updatedAt to UTC ISO 8601 to avoid locale-dependent DateTime formatting
+        $ts = if ($_.updatedAt -is [datetime]) { $_.updatedAt.ToUniversalTime().ToString('o') } else { "$($_.updatedAt)" }
+        "$($_.number):$ts"
+    } | Sort-Object)
     $hashInput = "total=$($prData.totalCount)|" + ($pairs -join '|')
 
     # Hash the probe data

--- a/scripts/Tests/ScriptHygiene.Tests.ps1
+++ b/scripts/Tests/ScriptHygiene.Tests.ps1
@@ -4,4 +4,46 @@ Describe 'Script hygiene' {
         $hits = Select-String -Path $script -Pattern '\bWrite-Output\b'
         $hits | Should -BeNullOrEmpty -Because 'Write-Output sends to stdout which is redirected to scan.json; use Write-Host or Write-Warning for diagnostics'
     }
+
+    It 'Workflow pwsh -Command in if-conditions must use explicit exit codes' {
+        # pwsh -Command "expr" always exits 0 regardless of expr's boolean value.
+        # Only exceptions cause non-zero exit. Any bash if-check that relies on
+        # the expression result as an exit code is silently broken.
+        $workflow = Join-Path $PSScriptRoot '../../.github/workflows/generate-reports.yml'
+        $content = Get-Content $workflow -Raw
+
+        # Find pwsh -Command invocations inside bash if-conditions
+        # Pattern: "if" ... "pwsh -Command" on the same logical line
+        $lines = $content -split "`n"
+        $violations = @()
+        $inPwshBlock = $false
+        $blockLines = @()
+        $blockStartLine = 0
+
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            $line = $lines[$i].Trim()
+
+            # Detect: if ... pwsh -Command (single-line or start of multi-line)
+            if ($line -match '^\s*if\b.*pwsh\s+(-NoProfile\s+)?-Command\b') {
+                $inPwshBlock = $true
+                $blockLines = @($line)
+                $blockStartLine = $i + 1
+            }
+            elseif ($inPwshBlock) {
+                $blockLines += $line
+            }
+
+            # End of the pwsh -Command block (the "; then" in bash)
+            if ($inPwshBlock -and $line -match ';\s*then\s*$') {
+                $block = $blockLines -join "`n"
+                if ($block -notmatch '\bexit\b') {
+                    $violations += "Line $blockStartLine : pwsh -Command in if-condition without explicit exit"
+                }
+                $inPwshBlock = $false
+                $blockLines = @()
+            }
+        }
+
+        $violations | Should -BeNullOrEmpty -Because 'pwsh -Command "expr" always exits 0; use explicit exit 0/exit 1 inside try/catch for reliable bash if-checks'
+    }
 }

--- a/scripts/Tests/ScriptHygiene.Tests.ps1
+++ b/scripts/Tests/ScriptHygiene.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'Script hygiene' {
+    It 'Get-PrTriageData.ps1 must not use Write-Output (stdout is JSON data)' {
+        $script = Join-Path $PSScriptRoot '../Get-PrTriageData.ps1'
+        $hits = Select-String -Path $script -Pattern '\bWrite-Output\b'
+        $hits | Should -BeNullOrEmpty -Because 'Write-Output sends to stdout which is redirected to scan.json; use Write-Host or Write-Warning for diagnostics'
+    }
+}

--- a/scripts/Tests/TestScanNeeded.Tests.ps1
+++ b/scripts/Tests/TestScanNeeded.Tests.ps1
@@ -231,6 +231,56 @@ Describe 'Test-ScanNeeded.ps1' {
             } finally { Remove-Item $f -ErrorAction SilentlyContinue }
         }
 
+        It 'returns false with multi-line (pretty-printed) gh output' {
+            # Ensures -join handles array-of-lines from gh CLI
+            $prs = @(
+                @{ number = 10; updatedAt = '2025-06-01T00:00:00Z'; ci = 'SUCCESS'; mergeable = 'MERGEABLE' },
+                @{ number = 20; updatedAt = '2025-06-02T00:00:00Z'; ci = 'SUCCESS'; mergeable = 'MERGEABLE' }
+            )
+            $hash = Get-ProbeHash -Prs $prs -TotalCount 2
+            $f = New-ScanFile @{
+                timestamp = (Get-Date).AddMinutes(-5).ToString('o')
+                prs = $prs
+                _probe_hash = $hash
+            }
+
+            # gh shim that returns pretty-printed multi-line JSON
+            $multiLineJson = @'
+{
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "totalCount": 2,
+        "nodes": [
+          { "number": 10, "updatedAt": "2025-06-01T00:00:00Z" },
+          { "number": 20, "updatedAt": "2025-06-02T00:00:00Z" }
+        ],
+        "pageInfo": { "hasNextPage": false, "endCursor": "abc" }
+      }
+    }
+  }
+}
+'@
+            if ($IsWindows) {
+                $ghShim = Join-Path $script:shimDir 'gh.cmd'
+                # Write multi-line JSON via a temp file so echo preserves newlines
+                $jsonFile = Join-Path $script:shimDir 'response.json'
+                $multiLineJson | Set-Content $jsonFile
+                "@echo off`ntype `"$jsonFile`"" | Set-Content $ghShim
+            } else {
+                $ghShim = Join-Path $script:shimDir 'gh'
+                $jsonFile = Join-Path $script:shimDir 'response.json'
+                $multiLineJson | Set-Content $jsonFile
+                "#!/bin/bash`ncat '$jsonFile'" | Set-Content $ghShim -NoNewline
+                chmod +x $ghShim
+            }
+
+            try {
+                $result = pwsh -NoProfile -Command "`$env:PATH = '$($script:shimDir)' + [IO.Path]::PathSeparator + `$env:PATH; & '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' 2>`$null"
+                $result | Should -Be 'false'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
+        }
+
         It 'returns true when hasNextPage is true (>100 PRs)' {
             $prs = @(
                 @{ number = 10; updatedAt = '2025-06-01T00:00:00Z'; ci = 'SUCCESS'; mergeable = 'MERGEABLE' }

--- a/scripts/Tests/TestScanNeeded.Tests.ps1
+++ b/scripts/Tests/TestScanNeeded.Tests.ps1
@@ -3,10 +3,16 @@ Describe 'Test-ScanNeeded.ps1' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'Test-ScanNeeded.ps1'
 
         # Helper: compute probe hash (same algorithm as Get-PrTriageData and Test-ScanNeeded)
+        # Canonicalizes updatedAt to UTC ISO 8601 to match production code
         function Get-ProbeHash {
             param([array]$Prs, [int]$TotalCount = -1)
             if ($TotalCount -lt 0) { $TotalCount = $Prs.Count }
-            $pairs = @($Prs | ForEach-Object { "$($_.number):$($_.updatedAt)" } | Sort-Object)
+            $jsonRoundTripped = ($Prs | ConvertTo-Json -Depth 5 | ConvertFrom-Json)
+            if ($Prs.Count -eq 1) { $jsonRoundTripped = @($jsonRoundTripped) }
+            $pairs = @($jsonRoundTripped | ForEach-Object {
+                $ts = if ($_.updatedAt -is [datetime]) { $_.updatedAt.ToUniversalTime().ToString('o') } else { "$($_.updatedAt)" }
+                "$($_.number):$ts"
+            } | Sort-Object)
             $input = "total=$TotalCount|" + ($pairs -join '|')
             $sha = [System.Security.Cryptography.SHA256]::Create()
             $bytes = [System.Text.Encoding]::UTF8.GetBytes($input)
@@ -156,6 +162,101 @@ Describe 'Test-ScanNeeded.ps1' {
                 $result = pwsh -NoProfile -Command "& '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$tmp' 2>`$null"
                 $result | Should -Be 'true'
             } finally { Remove-Item $tmp -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'GraphQL probe path (gh shim)' {
+        BeforeAll {
+            # Create a directory for the gh shim
+            $script:shimDir = Join-Path ([System.IO.Path]::GetTempPath()) "gh-shim-$([guid]::NewGuid())"
+            New-Item -ItemType Directory -Path $script:shimDir -Force | Out-Null
+        }
+        AfterAll {
+            Remove-Item $script:shimDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        It 'returns false when probe hash matches (skip scan)' {
+            # Build a scan.json with matching probe hash for 2 known PRs
+            $prs = @(
+                @{ number = 10; updatedAt = '2025-06-01T00:00:00Z'; ci = 'SUCCESS'; mergeable = 'MERGEABLE' },
+                @{ number = 20; updatedAt = '2025-06-02T00:00:00Z'; ci = 'SUCCESS'; mergeable = 'MERGEABLE' }
+            )
+            $hash = Get-ProbeHash -Prs $prs -TotalCount 2
+            $f = New-ScanFile @{
+                timestamp = (Get-Date).AddMinutes(-5).ToString('o')
+                prs = $prs
+                _probe_hash = $hash
+            }
+
+            # gh shim that returns matching GraphQL response
+            $json = '{"data":{"repository":{"pullRequests":{"totalCount":2,"nodes":[{"number":10,"updatedAt":"2025-06-01T00:00:00Z"},{"number":20,"updatedAt":"2025-06-02T00:00:00Z"}],"pageInfo":{"hasNextPage":false,"endCursor":"abc"}}}}}'
+            if ($IsWindows) {
+                $ghShim = Join-Path $script:shimDir 'gh.cmd'
+                "@echo off`necho $json" | Set-Content $ghShim
+            } else {
+                $ghShim = Join-Path $script:shimDir 'gh'
+                "#!/bin/bash`necho '$json'" | Set-Content $ghShim -NoNewline
+                chmod +x $ghShim
+            }
+
+            try {
+                $result = pwsh -NoProfile -Command "`$env:PATH = '$($script:shimDir)' + [IO.Path]::PathSeparator + `$env:PATH; & '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' 2>`$null"
+                $result | Should -Be 'false'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
+        }
+
+        It 'returns true when probe hash differs (scan needed)' {
+            $f = New-ScanFile @{
+                timestamp = (Get-Date).AddMinutes(-5).ToString('o')
+                prs = @(
+                    @{ number = 10; updatedAt = '2025-06-01T00:00:00Z'; ci = 'SUCCESS'; mergeable = 'MERGEABLE' }
+                )
+                _probe_hash = 'oldstalehashabcde'
+            }
+
+            # gh shim returns different data (PR 20 added)
+            $json = '{"data":{"repository":{"pullRequests":{"totalCount":2,"nodes":[{"number":10,"updatedAt":"2025-06-01T00:00:00Z"},{"number":20,"updatedAt":"2025-06-02T00:00:00Z"}],"pageInfo":{"hasNextPage":false,"endCursor":"abc"}}}}}'
+            if ($IsWindows) {
+                $ghShim = Join-Path $script:shimDir 'gh.cmd'
+                "@echo off`necho $json" | Set-Content $ghShim
+            } else {
+                $ghShim = Join-Path $script:shimDir 'gh'
+                "#!/bin/bash`necho '$json'" | Set-Content $ghShim -NoNewline
+                chmod +x $ghShim
+            }
+
+            try {
+                $result = pwsh -NoProfile -Command "`$env:PATH = '$($script:shimDir)' + [IO.Path]::PathSeparator + `$env:PATH; & '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' 2>`$null"
+                $result | Should -Be 'true'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
+        }
+
+        It 'returns true when hasNextPage is true (>100 PRs)' {
+            $prs = @(
+                @{ number = 10; updatedAt = '2025-06-01T00:00:00Z'; ci = 'SUCCESS'; mergeable = 'MERGEABLE' }
+            )
+            $hash = Get-ProbeHash -Prs $prs -TotalCount 1
+            $f = New-ScanFile @{
+                timestamp = (Get-Date).AddMinutes(-5).ToString('o')
+                prs = $prs
+                _probe_hash = $hash
+            }
+
+            # gh shim returns hasNextPage=true
+            $json = '{"data":{"repository":{"pullRequests":{"totalCount":150,"nodes":[{"number":10,"updatedAt":"2025-06-01T00:00:00Z"}],"pageInfo":{"hasNextPage":true,"endCursor":"abc"}}}}}'
+            if ($IsWindows) {
+                $ghShim = Join-Path $script:shimDir 'gh.cmd'
+                "@echo off`necho $json" | Set-Content $ghShim
+            } else {
+                $ghShim = Join-Path $script:shimDir 'gh'
+                "#!/bin/bash`necho '$json'" | Set-Content $ghShim -NoNewline
+                chmod +x $ghShim
+            }
+
+            try {
+                $result = pwsh -NoProfile -Command "`$env:PATH = '$($script:shimDir)' + [IO.Path]::PathSeparator + `$env:PATH; & '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' 2>`$null"
+                $result | Should -Be 'true'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
         }
     }
 }

--- a/scripts/Tests/TestScanNeeded.Tests.ps1
+++ b/scripts/Tests/TestScanNeeded.Tests.ps1
@@ -1,0 +1,161 @@
+Describe 'Test-ScanNeeded.ps1' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'Test-ScanNeeded.ps1'
+
+        # Helper: compute probe hash (same algorithm as Get-PrTriageData and Test-ScanNeeded)
+        function Get-ProbeHash {
+            param([array]$Prs, [int]$TotalCount = -1)
+            if ($TotalCount -lt 0) { $TotalCount = $Prs.Count }
+            $pairs = @($Prs | ForEach-Object { "$($_.number):$($_.updatedAt)" } | Sort-Object)
+            $input = "total=$TotalCount|" + ($pairs -join '|')
+            $sha = [System.Security.Cryptography.SHA256]::Create()
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($input)
+            [BitConverter]::ToString($sha.ComputeHash($bytes)).Replace('-', '').Substring(0, 16).ToLower()
+        }
+
+        # Helper: create a temp scan.json file
+        function New-ScanFile {
+            param([hashtable]$Data)
+            $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "test-scan-$([guid]::NewGuid()).json"
+            $Data | ConvertTo-Json -Depth 10 | Set-Content $tmp -Encoding UTF8
+            $tmp
+        }
+
+        # Common PR data for tests
+        $testPrs = @(
+            @{ number = 100; updatedAt = '2025-01-15T10:00:00Z' },
+            @{ number = 200; updatedAt = '2025-01-15T11:00:00Z' }
+        )
+        $script:goodHash = Get-ProbeHash -Prs $testPrs -TotalCount 2
+    }
+
+    Context 'Returns true (scan needed) when' {
+        It 'previous scan file does not exist' {
+            $result = pwsh -NoProfile -Command "& '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '/nonexistent/scan.json' 2>`$null"
+            $result | Should -Be 'true'
+        }
+
+        It 'previous scan has no timestamp' {
+            $f = New-ScanFile @{ prs = @(); _probe_hash = 'abc123' }
+            try {
+                $result = pwsh -NoProfile -Command "& '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' 2>`$null"
+                $result | Should -Be 'true'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
+        }
+
+        It 'previous scan is too old' {
+            $oldTimestamp = (Get-Date).AddHours(-5).ToString('o')
+            $f = New-ScanFile @{
+                timestamp = $oldTimestamp
+                prs = @()
+                _probe_hash = $script:goodHash
+            }
+            try {
+                # MaxSkipSeconds = 60 means 5h old scan is way past limit
+                $result = pwsh -NoProfile -Command "& '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' -MaxSkipSeconds 60 2>`$null"
+                $result | Should -Be 'true'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
+        }
+
+        It 'previous scan has unstable CI PRs' {
+            $f = New-ScanFile @{
+                timestamp = (Get-Date).AddMinutes(-10).ToString('o')
+                prs = @(
+                    @{ number = 100; ci = 'FAILURE'; mergeable = 'MERGEABLE' }
+                )
+                _probe_hash = $script:goodHash
+            }
+            try {
+                $result = pwsh -NoProfile -Command "& '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' 2>`$null"
+                $result | Should -Be 'true'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
+        }
+
+        It 'previous scan has UNKNOWN mergeable PRs' {
+            $f = New-ScanFile @{
+                timestamp = (Get-Date).AddMinutes(-10).ToString('o')
+                prs = @(
+                    @{ number = 100; ci = 'SUCCESS'; mergeable = 'UNKNOWN' }
+                )
+                _probe_hash = $script:goodHash
+            }
+            try {
+                $result = pwsh -NoProfile -Command "& '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' 2>`$null"
+                $result | Should -Be 'true'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
+        }
+
+        It 'previous scan has no _probe_hash' {
+            $f = New-ScanFile @{
+                timestamp = (Get-Date).AddMinutes(-10).ToString('o')
+                prs = @()
+            }
+            try {
+                $result = pwsh -NoProfile -Command "& '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$f' 2>`$null"
+                $result | Should -Be 'true'
+            } finally { Remove-Item $f -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'Probe hash computation' {
+        It 'matches Get-PrTriageData hash algorithm' {
+            # Verify our helper produces consistent hashes
+            $hash1 = Get-ProbeHash -Prs @(
+                @{ number = 1; updatedAt = '2025-01-01T00:00:00Z' }
+                @{ number = 2; updatedAt = '2025-01-02T00:00:00Z' }
+            )
+            $hash2 = Get-ProbeHash -Prs @(
+                @{ number = 2; updatedAt = '2025-01-02T00:00:00Z' }
+                @{ number = 1; updatedAt = '2025-01-01T00:00:00Z' }
+            )
+            $hash1 | Should -Be $hash2  # Order-independent
+        }
+
+        It 'changes when a PR is updated' {
+            $hash1 = Get-ProbeHash -Prs @(
+                @{ number = 1; updatedAt = '2025-01-01T00:00:00Z' }
+            )
+            $hash2 = Get-ProbeHash -Prs @(
+                @{ number = 1; updatedAt = '2025-01-01T01:00:00Z' }
+            )
+            $hash1 | Should -Not -Be $hash2
+        }
+
+        It 'changes when a PR is added' {
+            $hash1 = Get-ProbeHash -Prs @(
+                @{ number = 1; updatedAt = '2025-01-01T00:00:00Z' }
+            ) -TotalCount 1
+            $hash2 = Get-ProbeHash -Prs @(
+                @{ number = 1; updatedAt = '2025-01-01T00:00:00Z' }
+                @{ number = 2; updatedAt = '2025-01-02T00:00:00Z' }
+            ) -TotalCount 2
+            $hash1 | Should -Not -Be $hash2
+        }
+
+        It 'changes when totalCount differs' {
+            $hash1 = Get-ProbeHash -Prs @(
+                @{ number = 1; updatedAt = '2025-01-01T00:00:00Z' }
+            ) -TotalCount 100
+            $hash2 = Get-ProbeHash -Prs @(
+                @{ number = 1; updatedAt = '2025-01-01T00:00:00Z' }
+            ) -TotalCount 101
+            $hash1 | Should -Not -Be $hash2
+        }
+
+        It 'produces 16 hex characters' {
+            $hash = Get-ProbeHash -Prs @()
+            $hash | Should -Match '^[0-9a-f]{16}$'
+        }
+    }
+
+    Context 'Fail-safe behavior' {
+        It 'returns true when scan file contains invalid JSON' {
+            $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "test-bad-$([guid]::NewGuid()).json"
+            'not json{{{' | Set-Content $tmp
+            try {
+                $result = pwsh -NoProfile -Command "& '$scriptPath' -Repo 'owner/repo' -PreviousScanFile '$tmp' 2>`$null"
+                $result | Should -Be 'true'
+            } finally { Remove-Item $tmp -ErrorAction SilentlyContinue }
+        }
+    }
+}


### PR DESCRIPTION
## Phase 3: Lightweight probe to skip unchanged repos + API quota footer

Part of #54 (API quota optimization). Builds on Phase 1 (incremental scanning, #55).

### What this does

**Lightweight probe** - Before running a full/incremental scan for each repo, makes a single cheap GraphQL query (~1 API call) to check if anything changed. Skips the entire scan when:
- Probe hash (SHA256 of sorted PR numbers + updatedAt + totalCount) matches previous scan
- Previous scan is fresh (< 3 hours old)
- No unstable PRs in previous scan (non-SUCCESS CI or UNKNOWN mergeable)

Fail-safe: any error during probe returns "scan needed" -- never skips when in doubt.

**API quota footer** - After all scans complete, injects a `_rate_limit` snapshot (from the job-level rate_limit API call that already happens) into each processed scan.json. The footer.js displays remaining REST/GraphQL quota and reset time at the bottom of report pages.

### Files changed

- **`scripts/Test-ScanNeeded.ps1`** (new) - Standalone probe script called by the workflow
- **`scripts/Tests/TestScanNeeded.Tests.ps1`** (new) - 12 Pester tests covering pre-probe checks, hash algorithm, fail-safe behavior
- **`scripts/Get-PrTriageData.ps1`** - Computes and stores `_probe_hash` in scan output
- **`.github/workflows/generate-reports.yml`** - Probe skip logic + rate-limit injection into scan.json
- **`docs/footer.js`** (new) - Shared footer with quota display helper
- **`docs/all/actionable.html`** - Loads footer.js, passes `_rate_limit` to display

### Design decisions

- **0 extra API calls for footer**: Uses the existing job-start/end `rate_limit` snapshots. No per-repo overhead.
- **Only injects into processed repos**: Tracks `scanned_slugs[]` to avoid dirtying scan.json for repos not processed this run (e.g., standard-tier repos on non-daily runs).
- **Probe uses `first: 100`**: If a repo has >100 open PRs, probe can't match full scan hash, so it correctly returns "scan needed".
- **`_probe_hash` stored in scan.json**: 16-char hex SHA256 truncation. Both Test-ScanNeeded.ps1 and Get-PrTriageData.ps1 use identical algorithm.
- **Build-Reports always runs** even when probe skips scan, in case HTML templates changed.

### Expected quota savings

For repos with no PR activity between runs (common for standard-tier repos), this saves the entire incremental scan cost (~5-15 API calls per repo) and replaces it with 1 GraphQL call.

### Test results

74 Pester tests passing (24 Codeowners + 38 IncrementalScan + 12 TestScanNeeded).
