### PR TITLE
Add weekly auto-refresh workflow for maintainers

### DIFF
--- a/.github/workflows/refresh-maintainers.yml
+++ b/.github/workflows/refresh-maintainers.yml
@@ -42,14 +42,18 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          pushed=false
+          nothing_to_push=false
           for attempt in 1 2 3; do
             git add config/maintainers.json
             if git diff --cached --quiet; then
               echo "No changes to commit"
+              nothing_to_push=true
               break
             fi
             git commit -m "Auto-refresh maintainers list"
             if git push; then
+              pushed=true
               break
             fi
             echo "Push failed (attempt $attempt), retrying..."
@@ -57,3 +61,7 @@ jobs:
             git pull --rebase origin main
             sleep 5
           done
+          if [ "$pushed" != "true" ] && [ "$nothing_to_push" != "true" ]; then
+            echo "All push attempts failed."
+            exit 1
+          fi

--- a/.github/workflows/refresh-maintainers.yml
+++ b/.github/workflows/refresh-maintainers.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Run Update-Maintainers

--- a/.github/workflows/refresh-maintainers.yml
+++ b/.github/workflows/refresh-maintainers.yml
@@ -60,7 +60,7 @@ jobs:
             fi
             echo "Push failed (attempt $attempt), retrying..."
             git reset HEAD~1
-            git pull --rebase origin main
+            git pull --rebase --autostash origin main
             sleep 5
           done
           if [ "$pushed" != "true" ] && [ "$nothing_to_push" != "true" ]; then

--- a/.github/workflows/refresh-maintainers.yml
+++ b/.github/workflows/refresh-maintainers.yml
@@ -16,7 +16,9 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Run Update-Maintainers
         id: update

--- a/.github/workflows/refresh-maintainers.yml
+++ b/.github/workflows/refresh-maintainers.yml
@@ -1,0 +1,59 @@
+name: Refresh maintainers
+
+on:
+  schedule:
+    - cron: '37 3 * * 1'  # Monday 03:37 UTC (off-peak, avoids round numbers)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-maintainers
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Update-Maintainers
+        id: update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pwsh ./scripts/Update-Maintainers.ps1 -Days 90 -MinMerges 3
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet config/maintainers.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No maintainer changes detected."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Maintainer changes detected:"
+            git diff --stat config/maintainers.json
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          for attempt in 1 2 3; do
+            git add config/maintainers.json
+            if git diff --cached --quiet; then
+              echo "No changes to commit"
+              break
+            fi
+            git commit -m "Auto-refresh maintainers list"
+            if git push; then
+              break
+            fi
+            echo "Push failed (attempt $attempt), retrying..."
+            git reset HEAD~1
+            git pull --rebase origin main
+            sleep 5
+          done

--- a/scripts/MaintainersGuard.psm1
+++ b/scripts/MaintainersGuard.psm1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+    Safety-check helpers for Update-Maintainers.ps1.
+#>
+
+<#
+.SYNOPSIS
+    Validates that a proposed maintainers update is safe to apply.
+.DESCRIPTION
+    Checks two invariants:
+      1. No existing repo key would be lost.
+      2. The total maintainer count would not decrease.
+    Returns a result object: Safe (bool) and Reason (string, empty when Safe).
+.PARAMETER Existing
+    The current maintainers hashtable (keys are repo slugs, values are string arrays).
+.PARAMETER Proposed
+    The proposed (ordered) hashtable of maintainers to write.
+#>
+function Test-MaintainerSafety {
+    [CmdletBinding()]
+    param(
+        $Existing,
+        $Proposed
+    )
+
+    # Check 1: no existing repo key may be absent from the proposed output
+    $missingKeys = @($Existing.Keys | Where-Object { -not $Proposed.Contains($_) })
+    if ($missingKeys.Count -gt 0) {
+        return [PSCustomObject]@{
+            Safe     = $false
+            Reason   = "would lose repo keys: $($missingKeys | Sort-Object | Join-String -Separator ', ')"
+            OldTotal = ($Existing.Values | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum ?? 0
+            NewTotal = ($Proposed.Values  | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum ?? 0
+        }
+    }
+
+    # Check 2: total maintainer count must not decrease
+    $oldTotal = ($Existing.Values | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum ?? 0
+    $newTotal = ($Proposed.Values  | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum ?? 0
+    if ($newTotal -lt $oldTotal) {
+        return [PSCustomObject]@{
+            Safe     = $false
+            Reason   = "total maintainer count would decrease from $oldTotal to $newTotal"
+            OldTotal = $oldTotal
+            NewTotal = $newTotal
+        }
+    }
+
+    return [PSCustomObject]@{ Safe = $true; Reason = ''; OldTotal = $oldTotal; NewTotal = $newTotal }
+}

--- a/scripts/Tests/UpdateMaintainers.Tests.ps1
+++ b/scripts/Tests/UpdateMaintainers.Tests.ps1
@@ -1,0 +1,67 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/../MaintainersGuard.psm1" -Force
+}
+
+Describe 'Test-MaintainerSafety' {
+    It 'Returns safe when existing is empty' {
+        $existing = @{}
+        $proposed = [ordered]@{ 'a/b' = @('alice') }
+        $result = Test-MaintainerSafety -Existing $existing -Proposed $proposed
+        $result.Safe | Should -BeTrue
+    }
+
+    It 'Returns safe when count stays the same' {
+        $existing = @{ 'a/b' = @('alice', 'bob') }
+        $proposed = [ordered]@{ 'a/b' = @('alice', 'bob') }
+        $result = Test-MaintainerSafety -Existing $existing -Proposed $proposed
+        $result.Safe | Should -BeTrue
+    }
+
+    It 'Returns safe when count increases' {
+        $existing = @{ 'a/b' = @('alice') }
+        $proposed = [ordered]@{ 'a/b' = @('alice', 'bob') }
+        $result = Test-MaintainerSafety -Existing $existing -Proposed $proposed
+        $result.Safe | Should -BeTrue
+    }
+
+    It 'Returns safe when count increases across multiple repos' {
+        $existing = @{ 'a/b' = @('alice'); 'c/d' = @('bob') }
+        $proposed = [ordered]@{ 'a/b' = @('alice', 'carol'); 'c/d' = @('bob') }
+        $result = Test-MaintainerSafety -Existing $existing -Proposed $proposed
+        $result.Safe | Should -BeTrue
+    }
+
+    It 'Detects missing repo key' {
+        $existing = @{ 'a/b' = @('alice'); 'c/d' = @('carol') }
+        $proposed = [ordered]@{ 'a/b' = @('alice') }   # c/d is absent
+        $result = Test-MaintainerSafety -Existing $existing -Proposed $proposed
+        $result.Safe   | Should -BeFalse
+        $result.Reason | Should -BeLike '*would lose repo keys*'
+        $result.Reason | Should -BeLike '*c/d*'
+    }
+
+    It 'Detects total maintainer count decrease' {
+        $existing = @{ 'a/b' = @('alice', 'bob', 'carol') }
+        $proposed = [ordered]@{ 'a/b' = @('alice') }   # 3 → 1
+        $result = Test-MaintainerSafety -Existing $existing -Proposed $proposed
+        $result.Safe   | Should -BeFalse
+        $result.Reason | Should -BeLike '*decrease*'
+    }
+
+    It 'Detects count decrease spread across multiple repos' {
+        $existing = @{ 'a/b' = @('alice'); 'c/d' = @('bob', 'carol') }
+        $proposed = [ordered]@{ 'a/b' = @('alice'); 'c/d' = @('bob') }   # total 3 → 2
+        $result = Test-MaintainerSafety -Existing $existing -Proposed $proposed
+        $result.Safe   | Should -BeFalse
+        $result.Reason | Should -BeLike '*decrease*'
+    }
+
+    It 'Reports missing key before count decrease when both are violated' {
+        # Both conditions violated: c/d missing AND count drops
+        $existing = @{ 'a/b' = @('alice', 'bob'); 'c/d' = @('carol') }
+        $proposed = [ordered]@{ 'a/b' = @('alice') }   # c/d missing, total 3 → 1
+        $result = Test-MaintainerSafety -Existing $existing -Proposed $proposed
+        $result.Safe   | Should -BeFalse
+        $result.Reason | Should -BeLike '*would lose repo keys*'   # key loss reported first
+    }
+}

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -168,8 +168,7 @@ foreach ($repo in $existing.Keys | Sort-Object) {
 # Safety checks (key preservation + count non-decrease)
 $safetyResult = Test-MaintainerSafety -Existing $existing -Proposed $orderedObj
 if (-not $safetyResult.Safe) {
-    Write-Error "SAFETY ABORT: $($safetyResult.Reason)"
-    exit 1
+    throw "SAFETY ABORT: $($safetyResult.Reason)"
 }
 
 $oldTotal = $safetyResult.OldTotal

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -149,21 +149,43 @@ foreach ($entry in $repos) {
     }
 }
 
-if (-not $DryRun) {
-    # Build ordered output matching docs/repos.json order
-    $orderedObj = [ordered]@{}
-    foreach ($entry in $repos) {
-        $repo = $entry.repo
-        $orderedObj[$repo] = @($updated[$repo])
+# Build ordered output matching docs/repos.json order, preserving repos not in repos.json
+$orderedObj = [ordered]@{}
+foreach ($entry in $repos) {
+    $repo = $entry.repo
+    $orderedObj[$repo] = @($updated[$repo])
+}
+# Preserve existing repos not present in repos.json (e.g., newly added repos awaiting first scan)
+foreach ($repo in $existing.Keys | Sort-Object) {
+    if (-not $orderedObj.Contains($repo)) {
+        $orderedObj[$repo] = @($existing[$repo])
+        Write-Host "  ${repo}: preserved (not in repos.json)" -ForegroundColor Yellow
     }
+}
 
+# Safety check: never lose repo keys
+$missingKeys = @($existing.Keys | Where-Object { -not $orderedObj.Contains($_) })
+if ($missingKeys.Count -gt 0) {
+    Write-Error "SAFETY ABORT: would lose repo keys: $($missingKeys -join ', ')"
+    exit 1
+}
+
+# Safety check: total maintainer count must not decrease
+$oldTotal = ($existing.Values | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum
+$newTotal = ($orderedObj.Values | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum
+if ($newTotal -lt $oldTotal) {
+    Write-Error "SAFETY ABORT: total maintainer count would decrease from $oldTotal to $newTotal"
+    exit 1
+}
+
+if (-not $DryRun) {
     $json = $orderedObj | ConvertTo-Json -Depth 3
     Set-Content -Path $maintainersJsonPath -Value $json -Encoding utf8NoBOM
     Write-Host ""
-    Write-Host "Updated $maintainersJsonPath" -ForegroundColor Cyan
+    Write-Host "Updated $maintainersJsonPath ($oldTotal -> $newTotal maintainers)" -ForegroundColor Cyan
 } else {
     Write-Host ""
-    Write-Host "[DryRun] No files written." -ForegroundColor Yellow
+    Write-Host "[DryRun] No files written. ($oldTotal -> $newTotal maintainers)" -ForegroundColor Yellow
     foreach ($repo in ($updated.Keys | Sort-Object)) {
         $existingForRepo = @($existing[$repo] ?? @())
         $added = @($updated[$repo] | Where-Object { $_ -notin $existingForRepo })

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -40,6 +40,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Import-Module "$PSScriptRoot/MaintainersGuard.psm1" -Force
+
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if (-not (Test-Path (Join-Path $repoRoot 'docs' 'repos.json'))) {
     $repoRoot = Split-Path -Parent $PSScriptRoot
@@ -163,20 +165,15 @@ foreach ($repo in $existing.Keys | Sort-Object) {
     }
 }
 
-# Safety check: never lose repo keys
-$missingKeys = @($existing.Keys | Where-Object { -not $orderedObj.Contains($_) })
-if ($missingKeys.Count -gt 0) {
-    Write-Error "SAFETY ABORT: would lose repo keys: $($missingKeys -join ', ')"
+# Safety checks (key preservation + count non-decrease)
+$safetyResult = Test-MaintainerSafety -Existing $existing -Proposed $orderedObj
+if (-not $safetyResult.Safe) {
+    Write-Error "SAFETY ABORT: $($safetyResult.Reason)"
     exit 1
 }
 
-# Safety check: total maintainer count must not decrease
-$oldTotal = ($existing.Values | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum
-$newTotal = ($orderedObj.Values | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum
-if ($newTotal -lt $oldTotal) {
-    Write-Error "SAFETY ABORT: total maintainer count would decrease from $oldTotal to $newTotal"
-    exit 1
-}
+$oldTotal = $safetyResult.OldTotal
+$newTotal = $safetyResult.NewTotal
 
 if (-not $DryRun) {
     $json = $orderedObj | ConvertTo-Json -Depth 3


### PR DESCRIPTION
## Auto-refresh maintainers weekly

> [!NOTE]
> This PR description was AI/Copilot-generated.

Wires the existing `Update-Maintainers.ps1` script into a weekly cron workflow so maintainer lists stay current without manual updates.

### Schedule
- **Weekly Monday 03:37 UTC** (off-peak, avoids round numbers)
- Also supports `workflow_dispatch` for manual triggers

### Safety guardrails (absolute priority: never degrade the site)

1. **Additive only** — discovered maintainers are unioned with the existing list; nobody is ever removed
2. **Preserves repos not in `repos.json`** — newly added repos that haven't had their first scan yet won't be dropped from `maintainers.json`
3. **Aborts if total maintainer count would decrease** — catches any unexpected bulk removal
4. **Aborts if any existing repo key would be lost** — prevents silent data loss
5. **Per-repo API failures are non-fatal** — if a GraphQL query fails for one repo, existing maintainers for that repo are kept unchanged
6. **Push retry with rebase** (3 attempts) — handles races with `generate-reports` workflow
7. **Separate concurrency group** — won't cancel or be cancelled by report generation

### Files changed
- `scripts/Update-Maintainers.ps1` — added safety checks (repo key preservation, total count guard, missing-key abort)
- `.github/workflows/refresh-maintainers.yml` — new weekly cron workflow
