### PR TITLE
Don't include inferred 'who' in the involves list

### DIFF
--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -1044,14 +1044,17 @@ foreach ($pr in $refreshCandidates) {
     })
     $whyStr = $mergeWhy -join "&#10;"
 
-    # Build the "involved" list — all people connected to this PR (for involves: filtering)
+    # Build the "involved" list — people who explicitly participated in this PR.
+    # Deliberately excludes $who (the suggested next-action owner) because that is
+    # an *inferred* suggestion, not evidence of actual involvement.  Including it
+    # caused maintainers with write access but no real engagement to see every
+    # unowned PR in the repo on their "involves" view.
     $involvedSet = @{}
     if ($authorLogin) { $involvedSet[$authorLogin] = $true }
     if ($botTrigger) { $involvedSet[$botTrigger] = $true }
     foreach ($r in $reviewerLogins) { if ($r) { $involvedSet[$r] = $true } }
     foreach ($c in $allCommenters) { if ($c) { $involvedSet[$c] = $true } }
     foreach ($rr in $requestedReviewerLogins) { if ($rr) { $involvedSet[$rr] = $true } }
-    foreach ($w in $who) { if ($w -and $w -ne 'area owner') { $involvedSet[$w] = $true } }
     $involvedList = @($involvedSet.Keys | Sort-Object)
 
     $results += [PSCustomObject]@{


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Problem

The `?involves=true` filter shows PRs where a user is "involved" — authored, reviewed, commented, or was requested to review. However, it also included the inferred `who` field (the suggested next-action owner). This caused maintainers who happen to have write access — e.g. from merging a few of their own PRs — to see every unowned PR in repos they don't actively review.

For example, `danmoseley` is in `maintainers.json` for `dotnet/performance` (having merged 3+ PRs), so the fallback at line 499 (`if ($prOwners.Count -eq 0) { $prOwners = $Maintainers }`) puts them into `$who` for every PR without CODEOWNERS/area-label coverage, and then `$who` feeds into `$involvedSet`.

## Fix

Remove the `foreach ($w in $who)` propagation into `$involvedSet`. The "involved" list now reflects only **actual participation**: author, bot trigger, reviewers, commenters, and requested reviewers — not inferred suggestions of who should look next.
