### PR TITLE
Add retry with backoff and error logging for GraphQL queries

### DIFF
--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -129,7 +129,7 @@ foreach ($entry in $repos) {
         }
 
         $result = $null
-        $maxRetries = 3
+        $maxRetries = 5
         $succeeded = $false
         for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
             $errFile = [System.IO.Path]::GetTempFileName()

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -129,15 +129,54 @@ foreach ($entry in $repos) {
         }
 
         $result = $null
-        $result = gh api graphql -f query="$q" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "ERROR querying $repo (skipping)" -ForegroundColor Red
+        $maxRetries = 3
+        $succeeded = $false
+        for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
+            $errFile = [System.IO.Path]::GetTempFileName()
+            $errText = ''
+            try {
+                $result = gh api graphql -f query="$q" 2>$errFile
+                $exitCode = $LASTEXITCODE
+                if ($exitCode -ne 0) {
+                    $errText = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue) ?? ''
+                } else {
+                    # gh can return exit 0 with GraphQL-level errors in the body
+                    $parsed = $result | ConvertFrom-Json
+                    if ($parsed.errors) {
+                        $exitCode = 1
+                        $errText = ($parsed.errors | ForEach-Object { $_.message }) -join '; '
+                    } elseif (-not $parsed.data -or -not $parsed.data.search) {
+                        $exitCode = 1
+                        $errText = 'Response missing data.search'
+                    }
+                }
+                if ($exitCode -eq 0) {
+                    $succeeded = $true
+                    break
+                }
+            } finally {
+                Remove-Item -LiteralPath $errFile -ErrorAction SilentlyContinue
+            }
+            if ($attempt -lt $maxRetries) {
+                $delay = $attempt * 15
+                Write-Host "" # finish the "repo ..." line
+                Write-Host "    Attempt $attempt/$maxRetries failed: $($errText.Trim())" -ForegroundColor Yellow
+                Write-Host "    Retrying in ${delay}s..." -ForegroundColor Yellow
+                Start-Sleep -Seconds $delay
+                Write-Host "  $repo ... " -NoNewline  # re-print the prefix for the next attempt
+            } else {
+                Write-Host "" # finish the "repo ..." line
+                Write-Host "    Attempt $attempt/$maxRetries failed: $($errText.Trim())" -ForegroundColor Red
+            }
+        }
+        if (-not $succeeded) {
+            Write-Host "  ERROR querying $repo after $maxRetries attempts (skipping)" -ForegroundColor Red
             $mergerCounts = $null
             break
         }
 
-        $data = $result | ConvertFrom-Json
-        $searchData = $data.data.search
+        # $parsed was already validated inside the retry loop
+        $searchData = $parsed.data.search
 
         foreach ($node in $searchData.nodes) {
             if ($node.mergedBy -and $node.mergedBy.login) {

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -141,13 +141,21 @@ foreach ($entry in $repos) {
                     $errText = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue) ?? ''
                 } else {
                     # gh can return exit 0 with GraphQL-level errors in the body
-                    $parsed = $result | ConvertFrom-Json
-                    if ($parsed.errors) {
+                    try {
+                        $parsed = $result | ConvertFrom-Json
+                    } catch {
                         $exitCode = 1
-                        $errText = ($parsed.errors | ForEach-Object { $_.message }) -join '; '
-                    } elseif (-not $parsed.data -or -not $parsed.data.search) {
-                        $exitCode = 1
-                        $errText = 'Response missing data.search'
+                        $errText = "Failed to parse response: $($_.Exception.Message)"
+                        $parsed = $null
+                    }
+                    if ($parsed) {
+                        if ($parsed.errors) {
+                            $exitCode = 1
+                            $errText = ($parsed.errors | ForEach-Object { $_.message }) -join '; '
+                        } elseif (-not $parsed.data -or -not $parsed.data.search) {
+                            $exitCode = 1
+                            $errText = 'Response missing data.search'
+                        }
                     }
                 }
                 if ($exitCode -eq 0) {
@@ -157,16 +165,20 @@ foreach ($entry in $repos) {
             } finally {
                 Remove-Item -LiteralPath $errFile -ErrorAction SilentlyContinue
             }
+            $displayErr = $errText.Trim()
+            if ([string]::IsNullOrWhiteSpace($displayErr)) {
+                $displayErr = "gh api graphql exited with code $exitCode"
+            }
             if ($attempt -lt $maxRetries) {
                 $delay = $attempt * 15
                 Write-Host "" # finish the "repo ..." line
-                Write-Host "    Attempt $attempt/$maxRetries failed: $($errText.Trim())" -ForegroundColor Yellow
+                Write-Host "    Attempt $attempt/$maxRetries failed: $displayErr" -ForegroundColor Yellow
                 Write-Host "    Retrying in ${delay}s..." -ForegroundColor Yellow
                 Start-Sleep -Seconds $delay
                 Write-Host "  $repo ... " -NoNewline  # re-print the prefix for the next attempt
             } else {
                 Write-Host "" # finish the "repo ..." line
-                Write-Host "    Attempt $attempt/$maxRetries failed: $($errText.Trim())" -ForegroundColor Red
+                Write-Host "    Attempt $attempt/$maxRetries failed: $displayErr" -ForegroundColor Red
             }
         }
         if (-not $succeeded) {


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

The weekly `Update-Maintainers` workflow was silently skipping repos when `gh api graphql` failed (stderr was sent to `$null`). This meant transient API failures for large repos like `dotnet/dotnet` and `dotnet/roslyn` produced unhelpful `ERROR querying ... (skipping)` messages with no indication of the root cause.

### Changes

- **Retry with backoff**: GraphQL queries now retry up to 5 times with 15s/30s/45s/60s delays between attempts
- **Error logging**: Captures and logs the actual error from `gh` (stderr for CLI errors, GraphQL `errors` array for API-level errors, missing `data.search` for malformed responses)
- **Avoid redundant parsing**: JSON is parsed and validated inside the retry loop; the success path reuses the parsed object instead of re-parsing

### Example output on failure

```
  dotnet/dotnet ...
    Attempt 1/3 failed: {"message":"API rate limit exceeded..."}
    Retrying in 15s...
  dotnet/dotnet ...
    Attempt 2/3 failed: {"message":"API rate limit exceeded..."}
    Retrying in 30s...
  dotnet/dotnet ... 1000 merged PRs, 53 qualifying mergers (no changes)
```
