### PR TITLE
Extract GraphQL validation, add second-pass retry, refactor to eliminate duplication

### DIFF
--- a/scripts/GraphQLHelper.psm1
+++ b/scripts/GraphQLHelper.psm1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Helpers for parsing and validating GitHub GraphQL API responses.
+
+.DESCRIPTION
+    Extracted from Update-Maintainers.ps1 to enable unit testing under
+    Set-StrictMode -Version Latest.
+#>
+
+Set-StrictMode -Version Latest
+
+function Test-GraphQLResponse {
+    <#
+    .SYNOPSIS
+        Parses a raw JSON string from gh api graphql and validates the response.
+
+    .DESCRIPTION
+        Returns a PSCustomObject with:
+          - Success  [bool]   : $true when response contains data.search
+          - Parsed   [object] : the parsed PSCustomObject (or $null on failure)
+          - Error    [string] : human-readable error message (empty on success)
+
+    .PARAMETER RawJson
+        The raw JSON string returned by gh api graphql.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$RawJson
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RawJson)) {
+        return [PSCustomObject]@{
+            Success = $false
+            Parsed  = $null
+            Error   = 'Empty or null response'
+        }
+    }
+
+    $parsed = $null
+    try {
+        $parsed = $RawJson | ConvertFrom-Json
+    } catch {
+        return [PSCustomObject]@{
+            Success = $false
+            Parsed  = $null
+            Error   = "Failed to parse response: $($_.Exception.Message)"
+        }
+    }
+
+    # Guard against JSON null or non-object top-level values
+    if ($null -eq $parsed -or -not $parsed.PSObject) {
+        return [PSCustomObject]@{
+            Success = $false
+            Parsed  = $null
+            Error   = 'Response is not a JSON object'
+        }
+    }
+
+    # GraphQL-level errors (exit code 0 but errors in body)
+    if ($parsed.PSObject.Properties['errors']) {
+        $msgs = ($parsed.errors | ForEach-Object { $_.message }) -join '; '
+        if ([string]::IsNullOrWhiteSpace($msgs)) {
+            $msgs = 'GraphQL returned errors (no message details)'
+        }
+        return [PSCustomObject]@{
+            Success = $false
+            Parsed  = $parsed
+            Error   = $msgs
+        }
+    }
+
+    # Validate expected shape: data.search must exist and be non-null
+    if (-not $parsed.PSObject.Properties['data'] -or $null -eq $parsed.data) {
+        return [PSCustomObject]@{
+            Success = $false
+            Parsed  = $parsed
+            Error   = 'Response missing data.search'
+        }
+    }
+    if (-not $parsed.data.PSObject.Properties['search'] -or $null -eq $parsed.data.search) {
+        return [PSCustomObject]@{
+            Success = $false
+            Parsed  = $parsed
+            Error   = 'Response missing data.search'
+        }
+    }
+
+    return [PSCustomObject]@{
+        Success = $true
+        Parsed  = $parsed
+        Error   = ''
+    }
+}
+
+Export-ModuleMember -Function Test-GraphQLResponse

--- a/scripts/GraphQLHelper.psm1
+++ b/scripts/GraphQLHelper.psm1
@@ -16,7 +16,7 @@ function Test-GraphQLResponse {
 
     .DESCRIPTION
         Returns a PSCustomObject with:
-          - Success  [bool]   : $true when response contains data.search
+          - Success  [bool]   : $true when response contains data.search and no GraphQL errors
           - Parsed   [object] : the parsed PSCustomObject (or $null on failure)
           - Error    [string] : human-readable error message (empty on success)
 
@@ -50,7 +50,7 @@ function Test-GraphQLResponse {
     }
 
     # Guard against JSON null or non-object top-level values
-    if ($null -eq $parsed -or -not $parsed.PSObject) {
+    if ($null -eq $parsed -or $parsed -isnot [pscustomobject]) {
         return [PSCustomObject]@{
             Success = $false
             Parsed  = $null

--- a/scripts/Tests/GraphQLHelper.Tests.ps1
+++ b/scripts/Tests/GraphQLHelper.Tests.ps1
@@ -1,0 +1,162 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Pester tests for GraphQLHelper.psm1 – Test-GraphQLResponse validation.
+
+.DESCRIPTION
+    Exercises the GraphQL response parsing and validation logic that was
+    extracted from Update-Maintainers.ps1.  All tests run under
+    Set-StrictMode -Version Latest to catch property-access bugs
+    (the class of bug that caused the StrictMode crash on main).
+#>
+
+BeforeAll {
+    Set-StrictMode -Version Latest
+    Import-Module "$PSScriptRoot/../GraphQLHelper.psm1" -Force
+}
+
+Describe 'Test-GraphQLResponse' {
+
+    Context 'Valid responses' {
+        It 'Accepts a well-formed search response' {
+            $json = '{"data":{"search":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeTrue
+            $r.Error   | Should -BeNullOrEmpty
+            $r.Parsed.data.search.nodes | Should -HaveCount 0
+        }
+
+        It 'Accepts a response with search results' {
+            $json = '{"data":{"search":{"pageInfo":{"hasNextPage":true,"endCursor":"Y3Vyc29yOjE="},"nodes":[{"mergedBy":{"login":"alice"}}]}}}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeTrue
+            $r.Parsed.data.search.nodes | Should -HaveCount 1
+        }
+    }
+
+    Context 'GraphQL body errors' {
+        It 'Detects errors array in response' {
+            $json = '{"errors":[{"message":"API rate limit exceeded"}]}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*rate limit*'
+        }
+
+        It 'Joins multiple error messages' {
+            $json = '{"errors":[{"message":"first problem"},{"message":"second problem"}]}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*first problem*'
+            $r.Error   | Should -BeLike '*second problem*'
+        }
+
+        It 'Detects errors even when data is also present' {
+            # Some GraphQL APIs return partial data alongside errors
+            $json = '{"data":{"search":null},"errors":[{"message":"Something went wrong"}]}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*Something went wrong*'
+        }
+    }
+
+    Context 'Missing or malformed structure' {
+        It 'Fails when data is missing entirely' {
+            $json = '{"something":"else"}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*missing data.search*'
+        }
+
+        It 'Fails when data exists but search is missing' {
+            $json = '{"data":{"repository":{"name":"test"}}}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*missing data.search*'
+        }
+
+        It 'Fails on empty string' {
+            $r = Test-GraphQLResponse -RawJson ''
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*Empty*'
+        }
+
+        It 'Fails on whitespace-only input' {
+            $r = Test-GraphQLResponse -RawJson '   '
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*Empty*'
+        }
+
+        It 'Fails on invalid JSON' {
+            $r = Test-GraphQLResponse -RawJson 'not json at all'
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*Failed to parse*'
+        }
+
+        It 'Fails on truncated JSON' {
+            $r = Test-GraphQLResponse -RawJson '{"data":{"search":'
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*Failed to parse*'
+        }
+    }
+
+    Context 'Null and edge-case JSON values' {
+        It 'Fails on JSON null literal' {
+            $r = Test-GraphQLResponse -RawJson 'null'
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Does not throw on JSON null literal under StrictMode' {
+            { Test-GraphQLResponse -RawJson 'null' } | Should -Not -Throw
+        }
+
+        It 'Fails when data is null' {
+            $json = '{"data":null}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*missing data.search*'
+        }
+
+        It 'Does not throw when data is null under StrictMode' {
+            { Test-GraphQLResponse -RawJson '{"data":null}' } | Should -Not -Throw
+        }
+
+        It 'Fails when search is null' {
+            $json = '{"data":{"search":null}}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*missing data.search*'
+        }
+
+        It 'Handles empty errors array gracefully' {
+            $json = '{"errors":[]}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'StrictMode safety (regression)' {
+        # These tests specifically verify that property access does not throw
+        # under Set-StrictMode -Version Latest — the exact bug that broke main.
+
+        It 'Does not throw when checking errors on a response without errors property' {
+            # This is the exact scenario that caused the StrictMode crash:
+            # a valid response with data.search but no "errors" key
+            $json = '{"data":{"search":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}'
+            { Test-GraphQLResponse -RawJson $json } | Should -Not -Throw
+        }
+
+        It 'Does not throw when data property is absent' {
+            $json = '{"something":"else"}'
+            { Test-GraphQLResponse -RawJson $json } | Should -Not -Throw
+        }
+
+        It 'Does not throw on completely empty object' {
+            $json = '{}'
+            $r = Test-GraphQLResponse -RawJson $json
+            $r.Success | Should -BeFalse
+            $r.Error   | Should -BeLike '*missing data.search*'
+        }
+    }
+}

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -272,7 +272,7 @@ foreach ($entry in $repos) {
 
     # Union with existing
     $existingForRepo = @($existing[$repo] ?? @())
-    $merged = @($existingForRepo + $discovered | Select-Object -Unique | Sort-Object)
+    $merged = @($existingForRepo + $discovered | Sort-Object -Unique)
 
     $added = @($merged | Where-Object { $_ -notin $existingForRepo })
 
@@ -317,7 +317,7 @@ if ($failedRepos.Count -gt 0) {
             ForEach-Object { $_.Key })
 
         $existingForRepo = @($existing[$repo] ?? @())
-        $merged = @($existingForRepo + $discovered | Select-Object -Unique | Sort-Object)
+        $merged = @($existingForRepo + $discovered | Sort-Object -Unique)
         $added = @($merged | Where-Object { $_ -notin $existingForRepo })
         $updated[$repo] = $merged
 

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -58,6 +58,7 @@ $ErrorActionPreference = 'Stop'
 
 Import-Module "$PSScriptRoot/MaintainersGuard.psm1" -Force
 Import-Module "$PSScriptRoot/MaintainerActivity.psm1" -Force
+Import-Module "$PSScriptRoot/GraphQLHelper.psm1" -Force
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if (-not (Test-Path (Join-Path $repoRoot 'docs' 'repos.json'))) {
@@ -141,21 +142,11 @@ foreach ($entry in $repos) {
                     $errText = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue) ?? ''
                 } else {
                     # gh can return exit 0 with GraphQL-level errors in the body
-                    try {
-                        $parsed = $result | ConvertFrom-Json
-                    } catch {
+                    $validation = Test-GraphQLResponse -RawJson $result
+                    $parsed = $validation.Parsed
+                    if (-not $validation.Success) {
                         $exitCode = 1
-                        $errText = "Failed to parse response: $($_.Exception.Message)"
-                        $parsed = $null
-                    }
-                    if ($parsed) {
-                        if ($parsed.PSObject.Properties['errors']) {
-                            $exitCode = 1
-                            $errText = ($parsed.errors | ForEach-Object { $_.message }) -join '; '
-                        } elseif (-not $parsed.PSObject.Properties['data'] -or -not $parsed.data.PSObject.Properties['search']) {
-                            $exitCode = 1
-                            $errText = 'Response missing data.search'
-                        }
+                        $errText = $validation.Error
                     }
                 }
                 if ($exitCode -eq 0) {

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -60,6 +60,142 @@ Import-Module "$PSScriptRoot/MaintainersGuard.psm1" -Force
 Import-Module "$PSScriptRoot/MaintainerActivity.psm1" -Force
 Import-Module "$PSScriptRoot/GraphQLHelper.psm1" -Force
 
+# ─── Invoke-RepoMaintainerScan ────────────────────────────────────────────────
+# Scans a single repo for merged PRs via GitHub GraphQL API with retry/backoff.
+# Returns a result object with Success, MergerCounts, Activity, TotalFetched, Error.
+function Invoke-RepoMaintainerScan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$CutoffDate,
+        [Parameter(Mandatory)][string[]]$BotLogins,
+        [switch]$SkipActivity,
+        [string]$DisplayPrefix = '  ',
+        [int]$MaxRetries = 5
+    )
+
+    $mergerCounts = @{}
+    $repoActivity = @{}
+    $cursor = $null
+    $totalFetched = 0
+
+    do {
+        $afterClause = if ($cursor) { ", after: `"$cursor`"" } else { "" }
+        if ($SkipActivity) {
+            $q = "{ search(query: `"repo:$Repo is:pr is:merged merged:>$CutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } } } } }"
+        } else {
+            $q = "{ search(query: `"repo:$Repo is:pr is:merged merged:>$CutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } files(first: 100) { nodes { path } } labels(first: 20) { nodes { name } } } } } }"
+        }
+
+        $result = $null
+        $succeeded = $false
+        for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+            $errFile = [System.IO.Path]::GetTempFileName()
+            $errText = ''
+            try {
+                $result = gh api graphql -f query="$q" 2>$errFile
+                $exitCode = $LASTEXITCODE
+                if ($exitCode -ne 0) {
+                    $errText = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue) ?? ''
+                } else {
+                    $validation = Test-GraphQLResponse -RawJson $result
+                    $parsed = $validation.Parsed
+                    if (-not $validation.Success) {
+                        $exitCode = 1
+                        $errText = $validation.Error
+                    }
+                }
+                if ($exitCode -eq 0) {
+                    $succeeded = $true
+                    break
+                }
+            } finally {
+                Remove-Item -LiteralPath $errFile -ErrorAction SilentlyContinue
+            }
+            $displayErr = $errText.Trim()
+            if ([string]::IsNullOrWhiteSpace($displayErr)) {
+                $displayErr = "gh api graphql exited with code $exitCode"
+            }
+            if ($attempt -lt $MaxRetries) {
+                $delay = $attempt * 15
+                Write-Host ""
+                Write-Host "${DisplayPrefix}  Attempt $attempt/$MaxRetries failed: $displayErr" -ForegroundColor Yellow
+                Write-Host "${DisplayPrefix}  Retrying in ${delay}s..." -ForegroundColor Yellow
+                Start-Sleep -Seconds $delay
+                Write-Host "${DisplayPrefix}$Repo ... " -NoNewline
+            } else {
+                Write-Host ""
+                Write-Host "${DisplayPrefix}  Attempt $attempt/$MaxRetries failed: $displayErr" -ForegroundColor Red
+            }
+        }
+        if (-not $succeeded) {
+            return [PSCustomObject]@{
+                Success      = $false
+                MergerCounts = $null
+                Activity     = $null
+                TotalFetched = $totalFetched
+                Error        = "Failed after $MaxRetries attempts"
+            }
+        }
+
+        $searchData = $parsed.data.search
+        foreach ($node in $searchData.nodes) {
+            if ($node.mergedBy -and $node.mergedBy.login) {
+                $login = $node.mergedBy.login
+                if ($login -notin $BotLogins) {
+                    $mergerCounts[$login] = ($mergerCounts[$login] ?? 0) + 1
+
+                    if (-not $SkipActivity) {
+                        if (-not $repoActivity.ContainsKey($login)) {
+                            $repoActivity[$login] = @{
+                                paths  = [System.Collections.Generic.List[string]]@()
+                                labels = [System.Collections.Generic.List[string]]@()
+                                count  = 0
+                            }
+                        }
+                        if ($node.files -and $node.files.nodes) {
+                            foreach ($f in $node.files.nodes) {
+                                if ($f.path) {
+                                    $prefix = Get-PathPrefix $f.path
+                                    $repoActivity[$login].paths.Add($prefix)
+                                }
+                            }
+                        }
+                        if ($node.labels -and $node.labels.nodes) {
+                            foreach ($lbl in $node.labels.nodes) {
+                                if ($lbl.name -match '^area-') {
+                                    $repoActivity[$login].labels.Add($lbl.name)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            $totalFetched++
+        }
+
+        $hasNext = $searchData.pageInfo.hasNextPage
+        $cursor = $searchData.pageInfo.endCursor
+    } while ($hasNext)
+
+    # Add merge_count into activity entries
+    if (-not $SkipActivity) {
+        foreach ($login in @($mergerCounts.Keys)) {
+            if ($repoActivity.ContainsKey($login)) {
+                $repoActivity[$login].count = $mergerCounts[$login]
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        Success      = $true
+        MergerCounts = $mergerCounts
+        Activity     = $repoActivity
+        TotalFetched = $totalFetched
+        Error        = ''
+    }
+}
+
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if (-not (Test-Path (Join-Path $repoRoot 'docs' 'repos.json'))) {
     $repoRoot = Split-Path -Parent $PSScriptRoot
@@ -114,133 +250,18 @@ foreach ($entry in $repos) {
     $repo = $entry.repo
     Write-Host "  $repo ... " -NoNewline
 
-    $mergerCounts = @{}
-    # Per-login accumulation for activity signals (only when not skipped)
-    $repoActivity = @{}
-    $cursor = $null
-    $totalFetched = 0
+    $scanResult = Invoke-RepoMaintainerScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$SkipActivity
 
-    do {
-        $afterClause = if ($cursor) { ", after: `"$cursor`"" } else { "" }
-        if ($SkipActivity) {
-            $q = "{ search(query: `"repo:$repo is:pr is:merged merged:>$cutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } } } } }"
-        } else {
-            # files(first:100) and labels(first:20) are best-effort limits: PRs with more files or
-            # labels get partial data, which is acceptable for activity signal collection.
-            $q = "{ search(query: `"repo:$repo is:pr is:merged merged:>$cutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } files(first: 100) { nodes { path } } labels(first: 20) { nodes { name } } } } } }"
-        }
-
-        $result = $null
-        $maxRetries = 5
-        $succeeded = $false
-        for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
-            $errFile = [System.IO.Path]::GetTempFileName()
-            $errText = ''
-            try {
-                $result = gh api graphql -f query="$q" 2>$errFile
-                $exitCode = $LASTEXITCODE
-                if ($exitCode -ne 0) {
-                    $errText = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue) ?? ''
-                } else {
-                    # gh can return exit 0 with GraphQL-level errors in the body
-                    $validation = Test-GraphQLResponse -RawJson $result
-                    $parsed = $validation.Parsed
-                    if (-not $validation.Success) {
-                        $exitCode = 1
-                        $errText = $validation.Error
-                    }
-                }
-                if ($exitCode -eq 0) {
-                    $succeeded = $true
-                    break
-                }
-            } finally {
-                Remove-Item -LiteralPath $errFile -ErrorAction SilentlyContinue
-            }
-            $displayErr = $errText.Trim()
-            if ([string]::IsNullOrWhiteSpace($displayErr)) {
-                $displayErr = "gh api graphql exited with code $exitCode"
-            }
-            if ($attempt -lt $maxRetries) {
-                $delay = $attempt * 15
-                Write-Host "" # finish the "repo ..." line
-                Write-Host "    Attempt $attempt/$maxRetries failed: $displayErr" -ForegroundColor Yellow
-                Write-Host "    Retrying in ${delay}s..." -ForegroundColor Yellow
-                Start-Sleep -Seconds $delay
-                Write-Host "  $repo ... " -NoNewline  # re-print the prefix for the next attempt
-            } else {
-                Write-Host "" # finish the "repo ..." line
-                Write-Host "    Attempt $attempt/$maxRetries failed: $displayErr" -ForegroundColor Red
-            }
-        }
-        if (-not $succeeded) {
-            Write-Host "  ERROR querying $repo after $maxRetries attempts (skipping)" -ForegroundColor Red
-            $mergerCounts = $null
-            break
-        }
-
-        # $parsed was already validated inside the retry loop
-        $searchData = $parsed.data.search
-
-        foreach ($node in $searchData.nodes) {
-            if ($node.mergedBy -and $node.mergedBy.login) {
-                $login = $node.mergedBy.login
-                if ($login -notin $botLogins) {
-                    $mergerCounts[$login] = ($mergerCounts[$login] ?? 0) + 1
-
-                    if (-not $SkipActivity) {
-                        if (-not $repoActivity.ContainsKey($login)) {
-                            $repoActivity[$login] = @{
-                                paths  = [System.Collections.Generic.List[string]]@()
-                                labels = [System.Collections.Generic.List[string]]@()
-                                count  = 0
-                            }
-                        }
-                        # Collect file path prefixes (first 3 segments, e.g. src/libraries/System.IO).
-                        if ($node.files -and $node.files.nodes) {
-                            foreach ($f in $node.files.nodes) {
-                                if ($f.path) {
-                                    $prefix = Get-PathPrefix $f.path
-                                    $repoActivity[$login].paths.Add($prefix)
-                                }
-                            }
-                        }
-                        # Collect area-* labels
-                        if ($node.labels -and $node.labels.nodes) {
-                            foreach ($lbl in $node.labels.nodes) {
-                                if ($lbl.name -match '^area-') {
-                                    $repoActivity[$login].labels.Add($lbl.name)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            $totalFetched++
-        }
-
-        $hasNext = $searchData.pageInfo.hasNextPage
-        $cursor = $searchData.pageInfo.endCursor
-    } while ($hasNext)
-
-    # Skip repo if fetch failed — queue for second pass
-    if ($null -eq $mergerCounts) {
+    if (-not $scanResult.Success) {
+        Write-Host "  ERROR querying $repo ($($scanResult.Error)) — queued for retry" -ForegroundColor Red
         $failedRepos.Add($entry)
         $updated[$repo] = @($existing[$repo] ?? @())
         continue
     }
 
+    $mergerCounts = $scanResult.MergerCounts
     if (-not $SkipActivity) {
-        # Add merge_count from mergerCounts into each activity entry before storing.
-        # Invariant (holds because this block only runs when -SkipActivity is false): all logins
-        # in $mergerCounts also have a $repoActivity entry — both are populated in the inner loop
-        # above under the same `-not $SkipActivity` guard, so they stay in sync.
-        foreach ($login in @($mergerCounts.Keys)) {
-            if ($repoActivity.ContainsKey($login)) {
-                $repoActivity[$login].count = $mergerCounts[$login]
-            }
-        }
-        $activityAccum[$repo] = $repoActivity
+        $activityAccum[$repo] = $scanResult.Activity
     }
 
     # Apply threshold
@@ -257,7 +278,7 @@ foreach ($entry in $repos) {
 
     $updated[$repo] = $merged
 
-    Write-Host "$totalFetched merged PRs, $($discovered.Count) qualifying mergers" -NoNewline
+    Write-Host "$($scanResult.TotalFetched) merged PRs, $($discovered.Count) qualifying mergers" -NoNewline
     if ($added.Count -gt 0) {
         Write-Host " (+$($added.Count) new: $($added -join ', '))" -ForegroundColor Green
     } else {
@@ -278,119 +299,16 @@ if ($failedRepos.Count -gt 0) {
         $repo = $entry.repo
         Write-Host "  $repo (retry) ... " -NoNewline
 
-        $mergerCounts = @{}
-        $repoActivity = @{}
-        $cursor = $null
-        $totalFetched = 0
+        $scanResult = Invoke-RepoMaintainerScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$SkipActivity -DisplayPrefix '  '
 
-        do {
-            $afterClause = if ($cursor) { ", after: `"$cursor`"" } else { "" }
-            if ($SkipActivity) {
-                $q = "{ search(query: `"repo:$repo is:pr is:merged merged:>$cutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } } } } }"
-            } else {
-                $q = "{ search(query: `"repo:$repo is:pr is:merged merged:>$cutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } files(first: 100) { nodes { path } } labels(first: 20) { nodes { name } } } } } }"
-            }
-
-            $result = $null
-            $maxRetries = 5
-            $succeeded = $false
-            for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
-                $errFile = [System.IO.Path]::GetTempFileName()
-                $errText = ''
-                try {
-                    $result = gh api graphql -f query="$q" 2>$errFile
-                    $exitCode = $LASTEXITCODE
-                    if ($exitCode -ne 0) {
-                        $errText = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue) ?? ''
-                    } else {
-                        $validation = Test-GraphQLResponse -RawJson $result
-                        $parsed = $validation.Parsed
-                        if (-not $validation.Success) {
-                            $exitCode = 1
-                            $errText = $validation.Error
-                        }
-                    }
-                    if ($exitCode -eq 0) {
-                        $succeeded = $true
-                        break
-                    }
-                } finally {
-                    Remove-Item -LiteralPath $errFile -ErrorAction SilentlyContinue
-                }
-                $displayErr = $errText.Trim()
-                if ([string]::IsNullOrWhiteSpace($displayErr)) {
-                    $displayErr = "gh api graphql exited with code $exitCode"
-                }
-                if ($attempt -lt $maxRetries) {
-                    $delay = $attempt * 15
-                    Write-Host ""
-                    Write-Host "    Attempt $attempt/$maxRetries failed: $displayErr" -ForegroundColor Yellow
-                    Write-Host "    Retrying in ${delay}s..." -ForegroundColor Yellow
-                    Start-Sleep -Seconds $delay
-                    Write-Host "  $repo (retry) ... " -NoNewline
-                } else {
-                    Write-Host ""
-                    Write-Host "    Attempt $attempt/$maxRetries failed: $displayErr" -ForegroundColor Red
-                }
-            }
-            if (-not $succeeded) {
-                Write-Host "  ERROR querying $repo on second pass (giving up)" -ForegroundColor Red
-                $mergerCounts = $null
-                break
-            }
-
-            $searchData = $parsed.data.search
-            foreach ($node in $searchData.nodes) {
-                if ($node.mergedBy -and $node.mergedBy.login) {
-                    $login = $node.mergedBy.login
-                    if ($login -notin $botLogins) {
-                        $mergerCounts[$login] = ($mergerCounts[$login] ?? 0) + 1
-                        if (-not $SkipActivity) {
-                            if (-not $repoActivity.ContainsKey($login)) {
-                                $repoActivity[$login] = @{
-                                    paths  = [System.Collections.Generic.List[string]]@()
-                                    labels = [System.Collections.Generic.List[string]]@()
-                                    count  = 0
-                                }
-                            }
-                            if ($node.files -and $node.files.nodes) {
-                                foreach ($f in $node.files.nodes) {
-                                    if ($f.path) {
-                                        $prefix = Get-PathPrefix $f.path
-                                        $repoActivity[$login].paths.Add($prefix)
-                                    }
-                                }
-                            }
-                            if ($node.labels -and $node.labels.nodes) {
-                                foreach ($lbl in $node.labels.nodes) {
-                                    if ($lbl.name -match '^area-') {
-                                        $repoActivity[$login].labels.Add($lbl.name)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                $totalFetched++
-            }
-
-            $hasNext = $searchData.pageInfo.hasNextPage
-            $cursor = $searchData.pageInfo.endCursor
-        } while ($hasNext)
-
-        if ($null -eq $mergerCounts) {
-            # Still failed — keep existing entry
+        if (-not $scanResult.Success) {
+            Write-Host "  ERROR querying $repo on second pass (giving up)" -ForegroundColor Red
             continue
         }
 
-        # Success on second pass — process results
+        $mergerCounts = $scanResult.MergerCounts
         if (-not $SkipActivity) {
-            foreach ($login in @($mergerCounts.Keys)) {
-                if ($repoActivity.ContainsKey($login)) {
-                    $repoActivity[$login].count = $mergerCounts[$login]
-                }
-            }
-            $activityAccum[$repo] = $repoActivity
+            $activityAccum[$repo] = $scanResult.Activity
         }
 
         $discovered = @($mergerCounts.GetEnumerator() |
@@ -403,7 +321,7 @@ if ($failedRepos.Count -gt 0) {
         $added = @($merged | Where-Object { $_ -notin $existingForRepo })
         $updated[$repo] = $merged
 
-        Write-Host "$totalFetched merged PRs, $($discovered.Count) qualifying mergers" -NoNewline
+        Write-Host "$($scanResult.TotalFetched) merged PRs, $($discovered.Count) qualifying mergers" -NoNewline
         if ($added.Count -gt 0) {
             Write-Host " (+$($added.Count) new: $($added -join ', '))" -ForegroundColor Green
         } else {

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -108,6 +108,7 @@ Write-Host ""
 $updated = @{}
 # Per-repo, per-maintainer activity: filePaths buckets and area labels
 $activityAccum = @{}   # $activityAccum[$repo][$login] = @{ paths = [List]; labels = [List]; count = int }
+$failedRepos = [System.Collections.Generic.List[object]]@()   # entries to retry in a second pass
 
 foreach ($entry in $repos) {
     $repo = $entry.repo
@@ -222,8 +223,9 @@ foreach ($entry in $repos) {
         $cursor = $searchData.pageInfo.endCursor
     } while ($hasNext)
 
-    # Skip repo if fetch failed — keep existing entry unchanged
+    # Skip repo if fetch failed — queue for second pass
     if ($null -eq $mergerCounts) {
+        $failedRepos.Add($entry)
         $updated[$repo] = @($existing[$repo] ?? @())
         continue
     }
@@ -260,6 +262,153 @@ foreach ($entry in $repos) {
         Write-Host " (+$($added.Count) new: $($added -join ', '))" -ForegroundColor Green
     } else {
         Write-Host " (no changes)" -ForegroundColor DarkGray
+    }
+}
+
+# ─── Second pass: retry repos that failed in the first pass ───────────────────
+# By the time we reach here, minutes have elapsed processing other repos, giving
+# GitHub's API time to recover from transient 502/504 errors.
+if ($failedRepos.Count -gt 0) {
+    $retryDelay = 60
+    Write-Host ""
+    Write-Host "Retrying $($failedRepos.Count) failed repo(s) after ${retryDelay}s cooldown..." -ForegroundColor Yellow
+    Start-Sleep -Seconds $retryDelay
+
+    foreach ($entry in $failedRepos) {
+        $repo = $entry.repo
+        Write-Host "  $repo (retry) ... " -NoNewline
+
+        $mergerCounts = @{}
+        $repoActivity = @{}
+        $cursor = $null
+        $totalFetched = 0
+
+        do {
+            $afterClause = if ($cursor) { ", after: `"$cursor`"" } else { "" }
+            if ($SkipActivity) {
+                $q = "{ search(query: `"repo:$repo is:pr is:merged merged:>$cutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } } } } }"
+            } else {
+                $q = "{ search(query: `"repo:$repo is:pr is:merged merged:>$cutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } files(first: 100) { nodes { path } } labels(first: 20) { nodes { name } } } } } }"
+            }
+
+            $result = $null
+            $maxRetries = 5
+            $succeeded = $false
+            for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
+                $errFile = [System.IO.Path]::GetTempFileName()
+                $errText = ''
+                try {
+                    $result = gh api graphql -f query="$q" 2>$errFile
+                    $exitCode = $LASTEXITCODE
+                    if ($exitCode -ne 0) {
+                        $errText = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue) ?? ''
+                    } else {
+                        $validation = Test-GraphQLResponse -RawJson $result
+                        $parsed = $validation.Parsed
+                        if (-not $validation.Success) {
+                            $exitCode = 1
+                            $errText = $validation.Error
+                        }
+                    }
+                    if ($exitCode -eq 0) {
+                        $succeeded = $true
+                        break
+                    }
+                } finally {
+                    Remove-Item -LiteralPath $errFile -ErrorAction SilentlyContinue
+                }
+                $displayErr = $errText.Trim()
+                if ([string]::IsNullOrWhiteSpace($displayErr)) {
+                    $displayErr = "gh api graphql exited with code $exitCode"
+                }
+                if ($attempt -lt $maxRetries) {
+                    $delay = $attempt * 15
+                    Write-Host ""
+                    Write-Host "    Attempt $attempt/$maxRetries failed: $displayErr" -ForegroundColor Yellow
+                    Write-Host "    Retrying in ${delay}s..." -ForegroundColor Yellow
+                    Start-Sleep -Seconds $delay
+                    Write-Host "  $repo (retry) ... " -NoNewline
+                } else {
+                    Write-Host ""
+                    Write-Host "    Attempt $attempt/$maxRetries failed: $displayErr" -ForegroundColor Red
+                }
+            }
+            if (-not $succeeded) {
+                Write-Host "  ERROR querying $repo on second pass (giving up)" -ForegroundColor Red
+                $mergerCounts = $null
+                break
+            }
+
+            $searchData = $parsed.data.search
+            foreach ($node in $searchData.nodes) {
+                if ($node.mergedBy -and $node.mergedBy.login) {
+                    $login = $node.mergedBy.login
+                    if ($login -notin $botLogins) {
+                        $mergerCounts[$login] = ($mergerCounts[$login] ?? 0) + 1
+                        if (-not $SkipActivity) {
+                            if (-not $repoActivity.ContainsKey($login)) {
+                                $repoActivity[$login] = @{
+                                    paths  = [System.Collections.Generic.List[string]]@()
+                                    labels = [System.Collections.Generic.List[string]]@()
+                                    count  = 0
+                                }
+                            }
+                            if ($node.files -and $node.files.nodes) {
+                                foreach ($f in $node.files.nodes) {
+                                    if ($f.path) {
+                                        $prefix = Get-PathPrefix $f.path
+                                        $repoActivity[$login].paths.Add($prefix)
+                                    }
+                                }
+                            }
+                            if ($node.labels -and $node.labels.nodes) {
+                                foreach ($lbl in $node.labels.nodes) {
+                                    if ($lbl.name -match '^area-') {
+                                        $repoActivity[$login].labels.Add($lbl.name)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                $totalFetched++
+            }
+
+            $hasNext = $searchData.pageInfo.hasNextPage
+            $cursor = $searchData.pageInfo.endCursor
+        } while ($hasNext)
+
+        if ($null -eq $mergerCounts) {
+            # Still failed — keep existing entry
+            continue
+        }
+
+        # Success on second pass — process results
+        if (-not $SkipActivity) {
+            foreach ($login in @($mergerCounts.Keys)) {
+                if ($repoActivity.ContainsKey($login)) {
+                    $repoActivity[$login].count = $mergerCounts[$login]
+                }
+            }
+            $activityAccum[$repo] = $repoActivity
+        }
+
+        $discovered = @($mergerCounts.GetEnumerator() |
+            Where-Object { $_.Value -ge $MinMerges } |
+            Sort-Object Value -Descending |
+            ForEach-Object { $_.Key })
+
+        $existingForRepo = @($existing[$repo] ?? @())
+        $merged = @($existingForRepo + $discovered | Select-Object -Unique | Sort-Object)
+        $added = @($merged | Where-Object { $_ -notin $existingForRepo })
+        $updated[$repo] = $merged
+
+        Write-Host "$totalFetched merged PRs, $($discovered.Count) qualifying mergers" -NoNewline
+        if ($added.Count -gt 0) {
+            Write-Host " (+$($added.Count) new: $($added -join ', '))" -ForegroundColor Green
+        } else {
+            Write-Host " (no changes)" -ForegroundColor DarkGray
+        }
     }
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the help of GitHub Copilot.

## Extract GraphQL response validation + refactor retry logic

Extracts the inline GraphQL response parsing/validation logic into a dedicated testable module, adds a second-pass retry for repos that exhaust all attempts, and refactors both passes to share a single `Invoke-RepoMaintainerScan` function.

### What changed

- **`scripts/GraphQLHelper.psm1`** (new): `Test-GraphQLResponse` parses raw JSON from `gh api graphql` and validates the response structure. Returns a `Success`/`Parsed`/`Error` result object. Null-safe and StrictMode-safe.
- **`scripts/Tests/GraphQLHelper.Tests.ps1`** (new): 20 Pester tests covering:
  - Valid responses (empty and with results)
  - GraphQL body errors (single, multiple, partial data, empty array)
  - Missing/malformed structure (no data, no search, empty, truncated JSON)
  - Null edge cases (`null` literal, `data: null`, `search: null`)
  - **StrictMode regression tests** &#8212; the exact class of bug that broke main when `$parsed.errors` was accessed on a PSCustomObject without an `errors` property under `Set-StrictMode -Version Latest`
- **`scripts/Update-Maintainers.ps1`**:
  - New `Invoke-RepoMaintainerScan` function encapsulates per-repo logic: query building, pagination, retry/backoff with `Test-GraphQLResponse`, node processing, activity collection
  - Both first-pass and second-pass retry loops call this function, eliminating ~100 lines of duplicated code
  - Second-pass retry: tracks repos that exhaust all 5 attempts, waits 60s cooldown, retries them

### Why

The StrictMode crash that broke main ([fixed in ab86a21](https://github.com/danmoseley/pr-dashboard/commit/ab86a21)) would have been caught by these tests. The second-pass retry addresses transient GitHub API failures (502/504) that caused repos like `dotnet/dotnet-api-docs` to be silently skipped. The refactoring makes the code maintainable and testable.
