### PR TITLE
Fix display of missing cache version in incremental scan warning

### DIFF
--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -44,7 +44,8 @@ function Import-PreviousScan {
     try {
         $prevScan = Get-Content $Path -Raw | ConvertFrom-Json
         if ($prevScan._cache_version -ne $RequiredCacheVersion) {
-            $result.DisableReason = "cache version mismatch (got $($prevScan._cache_version), need $RequiredCacheVersion)"
+            $gotVer = if ($null -ne $prevScan._cache_version) { $prevScan._cache_version } else { '<none>' }
+            $result.DisableReason = "cache version mismatch (got $gotVer, need $RequiredCacheVersion)"
             return $result
         }
         if ($null -eq $prevScan.prs) {


### PR DESCRIPTION
When previous scan.json lacks `_cache_version` (pre-caching legacy file), the warning message showed `got , need 2` with a blank value. Now displays `got <none>, need 2` instead for clarity.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.