### PR TITLE
Add chunked date-range retry for large repos (502 fallback)

### DIFF
--- a/scripts/Tests/ChunkedRepoScan.Tests.ps1
+++ b/scripts/Tests/ChunkedRepoScan.Tests.ps1
@@ -1,0 +1,285 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Pester tests for Invoke-ChunkedRepoScan — the chunked date-range retry
+    logic added to handle large repos (e.g., dotnet/dotnet-api-docs) that
+    consistently return HTTP 502 on full-range GraphQL queries.
+
+.DESCRIPTION
+    Tests chunk computation, result merging, partial-failure handling, and
+    boundary correctness by mocking Invoke-RepoMaintainerScan.
+#>
+
+BeforeAll {
+    Set-StrictMode -Version Latest
+
+    # Source the script to get the functions (dot-source would execute the
+    # main body, so we extract functions only via a helper approach).
+    # Instead, we import the modules and define the functions in-scope.
+    Import-Module "$PSScriptRoot/../GraphQLHelper.psm1" -Force
+    Import-Module "$PSScriptRoot/../MaintainersGuard.psm1" -Force
+    Import-Module "$PSScriptRoot/../MaintainerActivity.psm1" -Force
+
+    # Dot-source just the function definitions by extracting them.
+    # We'll parse the script AST to avoid executing the main body.
+    $scriptPath = "$PSScriptRoot/../Update-Maintainers.ps1"
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
+    $functionDefs = $ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $false)
+    foreach ($funcDef in $functionDefs) {
+        . ([scriptblock]::Create($funcDef.Extent.Text))
+    }
+}
+
+Describe 'Invoke-ChunkedRepoScan' {
+
+    Context 'Chunk computation' {
+        It 'Creates correct number of chunks for 90-day window with 30-day chunks' {
+            $cutoff = (Get-Date).AddDays(-90).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $true; MergerCounts = @{}; Activity = @{}
+                    TotalFetched = 0; Error = ''
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30
+
+            # Should have 3 or 4 chunks (days 1-30, 31-60, 61-90ish)
+            Should -Invoke Invoke-RepoMaintainerScan -Times 3 -ParameterFilter { $EndDate }
+        }
+
+        It 'Creates a single chunk when window <= ChunkDays' {
+            $cutoff = (Get-Date).AddDays(-10).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $true; MergerCounts = @{}; Activity = @{}
+                    TotalFetched = 5; Error = ''
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30
+
+            $result.Success | Should -BeTrue
+            Should -Invoke Invoke-RepoMaintainerScan -Times 1 -Exactly
+        }
+
+        It 'Returns empty result when cutoff is in the future' {
+            $cutoff = (Get-Date).AddDays(5).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan { throw 'Should not be called' }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot')
+
+            $result.Success | Should -BeTrue
+            $result.TotalFetched | Should -Be 0
+            $result.MergerCounts.Count | Should -Be 0
+            Should -Invoke Invoke-RepoMaintainerScan -Times 0 -Exactly
+        }
+
+        It 'Produces non-overlapping date ranges' {
+            $cutoff = (Get-Date).AddDays(-90).ToString('yyyy-MM-dd')
+            $ranges = @()
+
+            Mock Invoke-RepoMaintainerScan {
+                $ranges += @{ Start = $CutoffDate; End = $EndDate }
+                [PSCustomObject]@{
+                    Success = $true; MergerCounts = @{}; Activity = @{}
+                    TotalFetched = 0; Error = ''
+                }
+            }
+
+            Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30 | Out-Null
+
+            # Verify no overlapping ranges
+            for ($i = 1; $i -lt $ranges.Count; $i++) {
+                $prevEnd = [datetime]::Parse($ranges[$i - 1].End)
+                $currStart = [datetime]::Parse($ranges[$i].Start)
+                $currStart | Should -BeGreaterThan $prevEnd -Because "chunk $i should start after chunk $($i-1) ends"
+            }
+        }
+
+        It 'First chunk starts the day after cutoff date (preserving merged:> semantics)' {
+            $cutoff = (Get-Date).AddDays(-45).ToString('yyyy-MM-dd')
+            $expectedStart = ([datetime]::Parse($cutoff)).AddDays(1).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $true; MergerCounts = @{}; Activity = @{}
+                    TotalFetched = 0; Error = ''
+                }
+            }
+
+            Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30 | Out-Null
+
+            # The first call should have CutoffDate = cutoff + 1 day
+            Should -Invoke Invoke-RepoMaintainerScan -Times 1 -ParameterFilter {
+                $CutoffDate -eq $expectedStart
+            }
+        }
+    }
+
+    Context 'Result merging' {
+        It 'Sums MergerCounts across chunks' {
+            $cutoff = (Get-Date).AddDays(-60).ToString('yyyy-MM-dd')
+            $chunk1Start = ([datetime]::Parse($cutoff)).AddDays(1).ToString('yyyy-MM-dd')
+            $chunk1End   = ([datetime]::Parse($cutoff)).AddDays(30).ToString('yyyy-MM-dd')
+
+            # First chunk returns alice=3, bob=2
+            Mock Invoke-RepoMaintainerScan -ParameterFilter { $CutoffDate -eq $chunk1Start } {
+                [PSCustomObject]@{
+                    Success = $true; TotalFetched = 50; Error = ''
+                    MergerCounts = @{ alice = 3; bob = 2 }; Activity = @{}
+                }
+            }
+            # All other chunks return alice=1, carol=4
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $true; TotalFetched = 30; Error = ''
+                    MergerCounts = @{ alice = 1; carol = 4 }; Activity = @{}
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30
+
+            $result.Success | Should -BeTrue
+            $result.TotalFetched | Should -Be 80
+            $result.MergerCounts['alice'] | Should -Be 4
+            $result.MergerCounts['bob']   | Should -Be 2
+            $result.MergerCounts['carol'] | Should -Be 4
+        }
+
+        It 'Merges activity paths and labels across chunks' {
+            $cutoff = (Get-Date).AddDays(-60).ToString('yyyy-MM-dd')
+            $chunk1Start = ([datetime]::Parse($cutoff)).AddDays(1).ToString('yyyy-MM-dd')
+            $chunk1End   = ([datetime]::Parse($cutoff)).AddDays(30).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan -ParameterFilter { $CutoffDate -eq $chunk1Start } {
+                $act = @{}
+                $act['alice'] = @{
+                    paths  = [System.Collections.Generic.List[string]]@('src/core')
+                    labels = [System.Collections.Generic.List[string]]@('area-io')
+                    count  = 2
+                }
+                [PSCustomObject]@{
+                    Success = $true; TotalFetched = 20; Error = ''
+                    MergerCounts = @{ alice = 2 }; Activity = $act
+                }
+            }
+            Mock Invoke-RepoMaintainerScan {
+                $act = @{}
+                $act['alice'] = @{
+                    paths  = [System.Collections.Generic.List[string]]@('src/net')
+                    labels = [System.Collections.Generic.List[string]]@('area-net')
+                    count  = 3
+                }
+                [PSCustomObject]@{
+                    Success = $true; TotalFetched = 15; Error = ''
+                    MergerCounts = @{ alice = 3 }; Activity = $act
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30
+
+            $result.Activity['alice'].count | Should -Be 5
+            $result.Activity['alice'].paths | Should -Contain 'src/core'
+            $result.Activity['alice'].paths | Should -Contain 'src/net'
+            $result.Activity['alice'].labels | Should -Contain 'area-io'
+            $result.Activity['alice'].labels | Should -Contain 'area-net'
+        }
+    }
+
+    Context 'Partial failure handling' {
+        It 'Returns partial results when some chunks fail' {
+            $cutoff = (Get-Date).AddDays(-60).ToString('yyyy-MM-dd')
+            $chunk1Start = ([datetime]::Parse($cutoff)).AddDays(1).ToString('yyyy-MM-dd')
+
+            # First chunk succeeds
+            Mock Invoke-RepoMaintainerScan -ParameterFilter { $CutoffDate -eq $chunk1Start } {
+                [PSCustomObject]@{
+                    Success = $true; TotalFetched = 50; Error = ''
+                    MergerCounts = @{ alice = 5 }; Activity = @{}
+                }
+            }
+            # Second chunk fails
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $false; TotalFetched = 0; Error = 'Failed after 5 attempts'
+                    MergerCounts = $null; Activity = $null
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30
+
+            $result.Success | Should -BeTrue  # partial success — at least one chunk worked
+            $result.TotalFetched | Should -Be 50
+            $result.MergerCounts['alice'] | Should -Be 5
+            $result.FailedChunks | Should -HaveCount 1
+            $result.Error | Should -BeLike '*Failed chunks*'
+        }
+
+        It 'Returns failure when all chunks fail' {
+            $cutoff = (Get-Date).AddDays(-60).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $false; TotalFetched = 0; Error = 'Failed after 5 attempts'
+                    MergerCounts = $null; Activity = $null
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30
+
+            $result.Success | Should -BeFalse
+            $result.TotalFetched | Should -Be 0
+            $result.FailedChunks.Count | Should -BeGreaterOrEqual 2
+        }
+
+        It 'FailedChunks is empty when all chunks succeed' {
+            $cutoff = (Get-Date).AddDays(-60).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $true; TotalFetched = 10; Error = ''
+                    MergerCounts = @{}; Activity = @{}
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30
+
+            $result.Success | Should -BeTrue
+            $result.FailedChunks | Should -HaveCount 0
+            $result.Error | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'EndDate parameter passed to scan' {
+        It 'Passes EndDate to Invoke-RepoMaintainerScan for each chunk' {
+            $cutoff = (Get-Date).AddDays(-30).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan {
+                $EndDate | Should -Not -BeNullOrEmpty -Because 'chunked scan must pass EndDate'
+                [PSCustomObject]@{
+                    Success = $true; MergerCounts = @{}; Activity = @{}
+                    TotalFetched = 0; Error = ''
+                }
+            }
+
+            Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 30 | Out-Null
+
+            Should -Invoke Invoke-RepoMaintainerScan -Times 1 -Exactly
+        }
+    }
+}

--- a/scripts/Tests/ChunkedRepoScan.Tests.ps1
+++ b/scripts/Tests/ChunkedRepoScan.Tests.ps1
@@ -47,7 +47,7 @@ Describe 'Invoke-ChunkedRepoScan' {
                 -BotLogins @('bot') -ChunkDays 30
 
             # Should have 3 chunks (days 1-30, 31-60, 61-90)
-            Should -Invoke Invoke-RepoMaintainerScan -Times 3 -ParameterFilter { $EndDate }
+            Should -Invoke Invoke-RepoMaintainerScan -Times 3 -Exactly -ParameterFilter { $EndDate }
         }
 
         It 'Creates a single chunk when window <= ChunkDays' {

--- a/scripts/Tests/ChunkedRepoScan.Tests.ps1
+++ b/scripts/Tests/ChunkedRepoScan.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'Invoke-ChunkedRepoScan' {
             $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
                 -BotLogins @('bot') -ChunkDays 30
 
-            # Should have 3 or 4 chunks (days 1-30, 31-60, 61-90ish)
+            # Should have 3 chunks (days 1-30, 31-60, 61-90)
             Should -Invoke Invoke-RepoMaintainerScan -Times 3 -ParameterFilter { $EndDate }
         }
 

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -233,15 +233,15 @@ function Invoke-ChunkedRepoScan {
         }
     }
 
-    $chunks = @()
+    $chunks = [System.Collections.Generic.List[hashtable]]::new()
     $chunkStart = $startDate
     while ($chunkStart -le $scanEnd) {
         $chunkEnd = $chunkStart.AddDays($ChunkDays - 1)
         if ($chunkEnd -gt $scanEnd) { $chunkEnd = $scanEnd }
-        $chunks += @{
+        $chunks.Add(@{
             Start = $chunkStart.ToString('yyyy-MM-dd')
             End   = $chunkEnd.ToString('yyyy-MM-dd')
-        }
+        })
         $chunkStart = $chunkEnd.AddDays(1)
     }
 
@@ -412,7 +412,7 @@ if ($failedRepos.Count -gt 0) {
 
     foreach ($entry in $failedRepos) {
         $repo = $entry.repo
-        Write-Host "  $repo (chunked retry) ... " -NoNewline
+        Write-Host "  $repo (chunked retry) ..."
 
         $scanResult = Invoke-ChunkedRepoScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$SkipActivity -DisplayPrefix '  '
 

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -69,6 +69,7 @@ function Invoke-RepoMaintainerScan {
         [Parameter(Mandatory)][string]$Repo,
         [Parameter(Mandatory)][string]$CutoffDate,
         [Parameter(Mandatory)][string[]]$BotLogins,
+        [string]$EndDate,
         [switch]$SkipActivity,
         [string]$DisplayPrefix = '  ',
         [int]$MaxRetries = 5
@@ -79,12 +80,16 @@ function Invoke-RepoMaintainerScan {
     $cursor = $null
     $totalFetched = 0
 
+    # Build the merged: filter — use a date range when EndDate is provided,
+    # otherwise use the open-ended >CutoffDate syntax.
+    $mergedFilter = if ($EndDate) { "merged:$CutoffDate..$EndDate" } else { "merged:>$CutoffDate" }
+
     do {
         $afterClause = if ($cursor) { ", after: `"$cursor`"" } else { "" }
         if ($SkipActivity) {
-            $q = "{ search(query: `"repo:$Repo is:pr is:merged merged:>$CutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } } } } }"
+            $q = "{ search(query: `"repo:$Repo is:pr is:merged $mergedFilter`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } } } } }"
         } else {
-            $q = "{ search(query: `"repo:$Repo is:pr is:merged merged:>$CutoffDate`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } files(first: 100) { nodes { path } } labels(first: 20) { nodes { name } } } } } }"
+            $q = "{ search(query: `"repo:$Repo is:pr is:merged $mergedFilter`", type: ISSUE, first: 100$afterClause) { pageInfo { hasNextPage endCursor } nodes { ... on PullRequest { mergedBy { login } files(first: 100) { nodes { path } } labels(first: 20) { nodes { name } } } } } }"
         }
 
         $result = $null
@@ -196,6 +201,115 @@ function Invoke-RepoMaintainerScan {
     }
 }
 
+# ─── Invoke-ChunkedRepoScan ──────────────────────────────────────────────────
+# Retries a failed repo by splitting the date range into smaller chunks.
+# Returns the same shape as Invoke-RepoMaintainerScan, with partial results
+# merged across successful chunks. FailedChunks lists any ranges that failed.
+function Invoke-ChunkedRepoScan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$CutoffDate,
+        [Parameter(Mandatory)][string[]]$BotLogins,
+        [switch]$SkipActivity,
+        [string]$DisplayPrefix = '  ',
+        [int]$MaxRetries = 5,
+        [ValidateRange(1, 365)][int]$ChunkDays = 30
+    )
+
+    # Compute non-overlapping date ranges from (CutoffDate + 1 day) to today.
+    # The original query uses merged:>CutoffDate (exclusive), so chunks start
+    # the day after CutoffDate to preserve semantics.
+    $startDate = ([datetime]::Parse($CutoffDate)).AddDays(1)
+    $scanEnd = (Get-Date).Date
+    if ($startDate -gt $scanEnd) {
+        return [PSCustomObject]@{
+            Success      = $true
+            MergerCounts = @{}
+            Activity     = @{}
+            TotalFetched = 0
+            FailedChunks = @()
+            Error        = ''
+        }
+    }
+
+    $chunks = @()
+    $chunkStart = $startDate
+    while ($chunkStart -le $scanEnd) {
+        $chunkEnd = $chunkStart.AddDays($ChunkDays - 1)
+        if ($chunkEnd -gt $scanEnd) { $chunkEnd = $scanEnd }
+        $chunks += @{
+            Start = $chunkStart.ToString('yyyy-MM-dd')
+            End   = $chunkEnd.ToString('yyyy-MM-dd')
+        }
+        $chunkStart = $chunkEnd.AddDays(1)
+    }
+
+    Write-Host ""
+    Write-Host "${DisplayPrefix}Splitting into $($chunks.Count) chunk(s) of up to $ChunkDays days" -ForegroundColor Cyan
+
+    $mergedCounts = @{}
+    $mergedActivity = @{}
+    $totalFetched = 0
+    $failedChunks = @()
+
+    foreach ($chunk in $chunks) {
+        Write-Host "${DisplayPrefix}  $Repo [$($chunk.Start)..$($chunk.End)] ... " -NoNewline
+
+        $scanResult = Invoke-RepoMaintainerScan -Repo $Repo -CutoffDate $chunk.Start -EndDate $chunk.End `
+            -BotLogins $BotLogins -SkipActivity:$SkipActivity -DisplayPrefix "${DisplayPrefix}  " -MaxRetries $MaxRetries
+
+        if (-not $scanResult.Success) {
+            Write-Host "FAILED ($($scanResult.Error))" -ForegroundColor Red
+            $failedChunks += "$($chunk.Start)..$($chunk.End)"
+            continue
+        }
+
+        $totalFetched += $scanResult.TotalFetched
+        Write-Host "$($scanResult.TotalFetched) PRs" -ForegroundColor Green
+
+        # Merge MergerCounts (sum by login)
+        if ($scanResult.MergerCounts) {
+            foreach ($kv in $scanResult.MergerCounts.GetEnumerator()) {
+                $mergedCounts[$kv.Key] = ($mergedCounts[$kv.Key] ?? 0) + $kv.Value
+            }
+        }
+
+        # Merge Activity (concatenate paths/labels lists, sum counts)
+        if (-not $SkipActivity -and $scanResult.Activity) {
+            foreach ($kv in $scanResult.Activity.GetEnumerator()) {
+                $login = $kv.Key
+                $acc = $kv.Value
+                if (-not $mergedActivity.ContainsKey($login)) {
+                    $mergedActivity[$login] = @{
+                        paths  = [System.Collections.Generic.List[string]]@()
+                        labels = [System.Collections.Generic.List[string]]@()
+                        count  = 0
+                    }
+                }
+                $mergedActivity[$login].count += $acc.count
+                foreach ($p in $acc.paths)  { $mergedActivity[$login].paths.Add($p) }
+                foreach ($l in $acc.labels) { $mergedActivity[$login].labels.Add($l) }
+            }
+        }
+    }
+
+    $anySuccess = ($failedChunks.Count -lt $chunks.Count)
+    $errorMsg = ''
+    if ($failedChunks.Count -gt 0) {
+        $errorMsg = "Failed chunks: $($failedChunks -join ', ')"
+    }
+
+    return [PSCustomObject]@{
+        Success      = $anySuccess
+        MergerCounts = $mergedCounts
+        Activity     = $mergedActivity
+        TotalFetched = $totalFetched
+        FailedChunks = $failedChunks
+        Error        = $errorMsg
+    }
+}
+
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if (-not (Test-Path (Join-Path $repoRoot 'docs' 'repos.json'))) {
     $repoRoot = Split-Path -Parent $PSScriptRoot
@@ -286,24 +400,32 @@ foreach ($entry in $repos) {
     }
 }
 
-# ─── Second pass: retry repos that failed in the first pass ───────────────────
-# By the time we reach here, minutes have elapsed processing other repos, giving
-# GitHub's API time to recover from transient 502/504 errors.
+# ─── Second pass: retry failed repos using chunked date ranges ────────────────
+# When a repo fails all retries (typically persistent 502 for large repos),
+# splitting the date range into smaller chunks often succeeds because each
+# chunk queries fewer results. A 60s cooldown gives the API time to recover.
 if ($failedRepos.Count -gt 0) {
     $retryDelay = 60
     Write-Host ""
-    Write-Host "Retrying $($failedRepos.Count) failed repo(s) after ${retryDelay}s cooldown..." -ForegroundColor Yellow
+    Write-Host "Retrying $($failedRepos.Count) failed repo(s) with chunked date ranges after ${retryDelay}s cooldown..." -ForegroundColor Yellow
     Start-Sleep -Seconds $retryDelay
 
     foreach ($entry in $failedRepos) {
         $repo = $entry.repo
-        Write-Host "  $repo (retry) ... " -NoNewline
+        Write-Host "  $repo (chunked retry) ... " -NoNewline
 
-        $scanResult = Invoke-RepoMaintainerScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$SkipActivity -DisplayPrefix '  '
+        $scanResult = Invoke-ChunkedRepoScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$SkipActivity -DisplayPrefix '  '
 
         if (-not $scanResult.Success) {
-            Write-Host "  ERROR querying $repo on second pass (giving up)" -ForegroundColor Red
+            Write-Host "  ERROR querying $repo on chunked retry (giving up)" -ForegroundColor Red
+            if ($scanResult.FailedChunks -and $scanResult.FailedChunks.Count -gt 0) {
+                Write-Host "    Failed chunks: $($scanResult.FailedChunks -join ', ')" -ForegroundColor DarkGray
+            }
             continue
+        }
+
+        if ($scanResult.PSObject.Properties['FailedChunks'] -and $scanResult.FailedChunks.Count -gt 0) {
+            Write-Host "    Partial success — failed chunks: $($scanResult.FailedChunks -join ', ')" -ForegroundColor Yellow
         }
 
         $mergerCounts = $scanResult.MergerCounts

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -82,6 +82,9 @@ function Invoke-RepoMaintainerScan {
 
     # Build the merged: filter — use a date range when EndDate is provided,
     # otherwise use the open-ended >CutoffDate syntax.
+    # Note: when EndDate is set, CutoffDate is treated as the inclusive start
+    # of a date range (merged:A..B). Callers (e.g. Invoke-ChunkedRepoScan)
+    # are responsible for adjusting dates to preserve the desired semantics.
     $mergedFilter = if ($EndDate) { "merged:$CutoffDate..$EndDate" } else { "merged:>$CutoffDate" }
 
     do {
@@ -251,7 +254,7 @@ function Invoke-ChunkedRepoScan {
     $mergedCounts = @{}
     $mergedActivity = @{}
     $totalFetched = 0
-    $failedChunks = @()
+    $failedChunks = [System.Collections.Generic.List[string]]::new()
 
     foreach ($chunk in $chunks) {
         Write-Host "${DisplayPrefix}  $Repo [$($chunk.Start)..$($chunk.End)] ... " -NoNewline
@@ -261,7 +264,7 @@ function Invoke-ChunkedRepoScan {
 
         if (-not $scanResult.Success) {
             Write-Host "FAILED ($($scanResult.Error))" -ForegroundColor Red
-            $failedChunks += "$($chunk.Start)..$($chunk.End)"
+            $failedChunks.Add("$($chunk.Start)..$($chunk.End)")
             continue
         }
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Problem

High-volume repos like `dotnet/dotnet-api-docs` consistently return HTTP 502 on the 90-day merged-PR GraphQL query. The existing retry logic (5 attempts with backoff) doesn't help because the query itself is too large for GitHub's backend.

## Solution

When the first pass fails for a repo, the second pass now splits the 90-day window into **30-day chunks** and queries each independently. This reduces per-query result volume, avoiding the 502.

### Changes

- **`Invoke-RepoMaintainerScan`**: Added optional `EndDate` parameter to support `merged:A..B` date-range queries (instead of `merged:>A`)
- **`Invoke-ChunkedRepoScan`** (new): Computes non-overlapping 30-day chunks, scans each via `Invoke-RepoMaintainerScan`, and merges results:
  - `MergerCounts` summed by login
  - Activity `paths`/`labels` concatenated (downstream aggregation handles frequency counting)
  - Partial success supported: returns data from successful chunks even if some fail
- **Second pass**: Now calls `Invoke-ChunkedRepoScan` instead of retrying with the same full-range query
- **Validation**: `ChunkDays` parameter validated to 1-365

### Tests

11 new Pester tests covering:
- Chunk computation (correct count, single chunk, future cutoff, non-overlapping ranges, start-day semantics)
- Result merging (MergerCounts summing, Activity concatenation)
- Partial failure handling (some chunks fail, all chunks fail, no failures)
- EndDate parameter passing

All 132 tests pass (121 existing + 11 new).
