### PR TITLE
Reduce chunk size to 7 days and fix duplicate retry log line

### DIFF
--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -130,7 +130,6 @@ function Invoke-RepoMaintainerScan {
                 Write-Host "${DisplayPrefix}  Attempt $attempt/$MaxRetries failed: $displayErr" -ForegroundColor Yellow
                 Write-Host "${DisplayPrefix}  Retrying in ${delay}s..." -ForegroundColor Yellow
                 Start-Sleep -Seconds $delay
-                Write-Host "${DisplayPrefix}$Repo ... " -NoNewline
             } else {
                 Write-Host ""
                 Write-Host "${DisplayPrefix}  Attempt $attempt/$MaxRetries failed: $displayErr" -ForegroundColor Red
@@ -217,7 +216,7 @@ function Invoke-ChunkedRepoScan {
         [switch]$SkipActivity,
         [string]$DisplayPrefix = '  ',
         [int]$MaxRetries = 5,
-        [ValidateRange(1, 365)][int]$ChunkDays = 30
+        [ValidateRange(1, 365)][int]$ChunkDays = 7
     )
 
     # Compute non-overlapping date ranges from (CutoffDate + 1 day) to today.


### PR DESCRIPTION
Reduce chunk size to 7 days and fix duplicate retry log line

- **ChunkDays 30 -> 7**: dotnet/dotnet-api-docs still hits 502s with 30-day chunks due to high PR volume. 7-day windows keep each query small enough to succeed. (90 days = ~13 chunks instead of 3.)
- **Fix duplicate log line**: `Invoke-RepoMaintainerScan` re-printed the repo name after each retry sleep, but the caller already printed it, producing doubled output like:
  ```
    dotnet/roslyn ...
      Attempt 1/5 failed: stream error: ...
      Retrying in 15s...
    dotnet/roslyn ...       <-- duplicate, now removed
  ```

> [!NOTE]
> This description was AI/Copilot-generated.
