### PR TITLE
Adaptive sub-chunking for failed API queries

### DIFF
--- a/scripts/Tests/ChunkedRepoScan.Tests.ps1
+++ b/scripts/Tests/ChunkedRepoScan.Tests.ps1
@@ -218,7 +218,7 @@ Describe 'Invoke-ChunkedRepoScan' {
             }
 
             $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
-                -BotLogins @('bot') -ChunkDays 30
+                -BotLogins @('bot') -ChunkDays 30 -MinChunkDays 30
 
             $result.Success | Should -BeTrue  # partial success — at least one chunk worked
             $result.TotalFetched | Should -Be 50
@@ -238,7 +238,7 @@ Describe 'Invoke-ChunkedRepoScan' {
             }
 
             $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
-                -BotLogins @('bot') -ChunkDays 30
+                -BotLogins @('bot') -ChunkDays 30 -MinChunkDays 30
 
             $result.Success | Should -BeFalse
             $result.TotalFetched | Should -Be 0
@@ -280,6 +280,119 @@ Describe 'Invoke-ChunkedRepoScan' {
                 -BotLogins @('bot') -ChunkDays 30 | Out-Null
 
             Should -Invoke Invoke-RepoMaintainerScan -Times 1 -Exactly
+        }
+    }
+
+    Context 'Adaptive sub-chunking' {
+        It 'Sub-chunks a failed 7-day chunk into 1-day ranges and merges results' {
+            # Use a 14-day window with 7-day chunks => 2 chunks
+            $cutoff = (Get-Date).AddDays(-14).ToString('yyyy-MM-dd')
+            $chunk1Start = ([datetime]::Parse($cutoff)).AddDays(1).ToString('yyyy-MM-dd')
+            $chunk1End   = ([datetime]::Parse($cutoff)).AddDays(7).ToString('yyyy-MM-dd')
+
+            # First 7-day chunk succeeds
+            Mock Invoke-RepoMaintainerScan -ParameterFilter { $CutoffDate -eq $chunk1Start } {
+                [PSCustomObject]@{
+                    Success = $true; TotalFetched = 40; Error = ''
+                    MergerCounts = @{ alice = 3 }; Activity = @{}
+                }
+            }
+            # All other calls: fail if range > 1 day, succeed if 1-day range
+            Mock Invoke-RepoMaintainerScan {
+                $start = [datetime]::Parse($CutoffDate)
+                $end   = [datetime]::Parse($EndDate)
+                $span  = ($end - $start).Days
+                if ($span -gt 0) {
+                    [PSCustomObject]@{
+                        Success = $false; TotalFetched = 0; Error = '502'
+                        MergerCounts = $null; Activity = $null
+                    }
+                } else {
+                    [PSCustomObject]@{
+                        Success = $true; TotalFetched = 2; Error = ''
+                        MergerCounts = @{ bob = 1 }; Activity = @{}
+                    }
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 7 -MinChunkDays 1
+
+            $result.Success | Should -BeTrue
+            $result.MergerCounts['alice'] | Should -Be 3
+            $result.MergerCounts['bob'] | Should -BeGreaterOrEqual 1
+            $result.FailedChunks | Should -HaveCount 0
+            $result.TotalFetched | Should -BeGreaterThan 40
+        }
+
+        It 'Reports 1-day failures as FailedChunks when MinChunkDays reached' {
+            $cutoff = (Get-Date).AddDays(-7).ToString('yyyy-MM-dd')
+
+            # Everything fails at every granularity
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $false; TotalFetched = 0; Error = '502'
+                    MergerCounts = $null; Activity = $null
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 7 -MinChunkDays 1
+
+            $result.Success | Should -BeFalse
+            # Should have individual 1-day failures, not 7-day chunk failures
+            foreach ($fc in $result.FailedChunks) {
+                $parts = $fc -split '\.\.'
+                $start = [datetime]::Parse($parts[0])
+                $end   = [datetime]::Parse($parts[1])
+                ($end - $start).Days | Should -Be 0 -Because "failed chunks should be 1-day ranges at MinChunkDays"
+            }
+        }
+
+        It 'Does not sub-chunk when ChunkDays equals MinChunkDays' {
+            $cutoff = (Get-Date).AddDays(-14).ToString('yyyy-MM-dd')
+
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $false; TotalFetched = 0; Error = '502'
+                    MergerCounts = $null; Activity = $null
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -BotLogins @('bot') -ChunkDays 7 -MinChunkDays 7
+
+            # With MinChunkDays=ChunkDays, no sub-chunking should occur.
+            # FailedChunks should be 7-day ranges, not 1-day ranges.
+            $result.Success | Should -BeFalse
+            foreach ($fc in $result.FailedChunks) {
+                $parts = $fc -split '\.\.'
+                $start = [datetime]::Parse($parts[0])
+                $end   = [datetime]::Parse($parts[1])
+                ($end - $start).Days | Should -BeLessOrEqual 6 -Because "chunks are up to 7 days"
+            }
+        }
+
+        It 'Respects EndDate parameter for bounded sub-chunking' {
+            $cutoff = '2026-03-01'
+            $endDate = '2026-03-14'
+
+            Mock Invoke-RepoMaintainerScan {
+                [PSCustomObject]@{
+                    Success = $true; TotalFetched = 5; Error = ''
+                    MergerCounts = @{ carol = 2 }; Activity = @{}
+                }
+            }
+
+            $result = Invoke-ChunkedRepoScan -Repo 'test/repo' -CutoffDate $cutoff `
+                -EndDate $endDate -BotLogins @('bot') -ChunkDays 7
+
+            $result.Success | Should -BeTrue
+            $result.TotalFetched | Should -Be 10   # 2 chunks of 5
+            # Verify no scan extends beyond EndDate
+            Should -Invoke Invoke-RepoMaintainerScan -ParameterFilter {
+                -not $EndDate -or [datetime]::Parse($EndDate) -le [datetime]::Parse('2026-03-14')
+            }
         }
     }
 }

--- a/scripts/Tests/ChunkedRepoScan.Tests.ps1
+++ b/scripts/Tests/ChunkedRepoScan.Tests.ps1
@@ -288,7 +288,6 @@ Describe 'Invoke-ChunkedRepoScan' {
             # Use a 14-day window with 7-day chunks => 2 chunks
             $cutoff = (Get-Date).AddDays(-14).ToString('yyyy-MM-dd')
             $chunk1Start = ([datetime]::Parse($cutoff)).AddDays(1).ToString('yyyy-MM-dd')
-            $chunk1End   = ([datetime]::Parse($cutoff)).AddDays(7).ToString('yyyy-MM-dd')
 
             # First 7-day chunk succeeds
             Mock Invoke-RepoMaintainerScan -ParameterFilter { $CutoffDate -eq $chunk1Start } {

--- a/scripts/Tests/ChunkedRepoScan.Tests.ps1
+++ b/scripts/Tests/ChunkedRepoScan.Tests.ps1
@@ -389,10 +389,11 @@ Describe 'Invoke-ChunkedRepoScan' {
 
             $result.Success | Should -BeTrue
             $result.TotalFetched | Should -Be 10   # 2 chunks of 5
-            # Verify no scan extends beyond EndDate
+            # Verify all scan calls respect the EndDate bound
+            Should -Invoke Invoke-RepoMaintainerScan -Times 2 -Exactly
             Should -Invoke Invoke-RepoMaintainerScan -ParameterFilter {
                 -not $EndDate -or [datetime]::Parse($EndDate) -le [datetime]::Parse('2026-03-14')
-            }
+            } -Times 2 -Exactly
         }
     }
 }

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -255,11 +255,14 @@ function Invoke-ChunkedRepoScan {
         [string]$EndDate   # optional: limit scan to this date instead of today
     )
 
+    # Clamp MinChunkDays to ChunkDays if misconfigured
+    if ($MinChunkDays -gt $ChunkDays) { $MinChunkDays = $ChunkDays }
+
     # Compute non-overlapping date ranges from (CutoffDate + 1 day) to EndDate (or today).
     # The original query uses merged:>CutoffDate (exclusive), so chunks start
     # the day after CutoffDate to preserve semantics.
     $startDate = ([datetime]::Parse($CutoffDate)).AddDays(1)
-     $scanEnd = if ($EndDate) { ([datetime]::Parse($EndDate)).Date } else { (Get-Date).Date }
+    $scanEnd = if ($EndDate) { ([datetime]::Parse($EndDate)).Date } else { (Get-Date).Date }
     if ($startDate -gt $scanEnd) {
         return [PSCustomObject]@{
             Success      = $true
@@ -312,7 +315,7 @@ function Invoke-ChunkedRepoScan {
                     -MaxRetries $MaxRetries -ChunkDays $subChunkDays -MinChunkDays $MinChunkDays
 
                 # Merge successful sub-chunk results
-                Merge-ScanResult $subResult $mergedCounts $mergedActivity (-not $SkipActivity) ([ref]$totalFetched)
+                Merge-ScanResult -Result $subResult -MergedCounts $mergedCounts -MergedActivity $mergedActivity -IncludeActivity (-not $SkipActivity) -TotalFetched ([ref]$totalFetched)
                 # Propagate any sub-chunk failures
                 if ($subResult.FailedChunks) {
                     foreach ($fc in $subResult.FailedChunks) { $failedChunks.Add($fc) }
@@ -328,7 +331,7 @@ function Invoke-ChunkedRepoScan {
 
         $anyChunkSucceeded = $true
         Write-Host "$($scanResult.TotalFetched) PRs" -ForegroundColor Green
-        Merge-ScanResult $scanResult $mergedCounts $mergedActivity (-not $SkipActivity) ([ref]$totalFetched)
+        Merge-ScanResult -Result $scanResult -MergedCounts $mergedCounts -MergedActivity $mergedActivity -IncludeActivity (-not $SkipActivity) -TotalFetched ([ref]$totalFetched)
     }
 
     $anySuccess = $anyChunkSucceeded

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -259,7 +259,7 @@ function Invoke-ChunkedRepoScan {
     # The original query uses merged:>CutoffDate (exclusive), so chunks start
     # the day after CutoffDate to preserve semantics.
     $startDate = ([datetime]::Parse($CutoffDate)).AddDays(1)
-     $scanEnd = if ($EndDate) { [datetime]::Parse($EndDate) } else { (Get-Date).Date }
+     $scanEnd = if ($EndDate) { ([datetime]::Parse($EndDate)).Date } else { (Get-Date).Date }
     if ($startDate -gt $scanEnd) {
         return [PSCustomObject]@{
             Success      = $true

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -203,6 +203,40 @@ function Invoke-RepoMaintainerScan {
     }
 }
 
+# ─── Merge-ScanResult ────────────────────────────────────────────────────────
+# Merges MergerCounts and Activity from a scan result into running accumulators.
+function Merge-ScanResult {
+    param(
+        [Parameter(Mandatory)][PSCustomObject]$Result,
+        [Parameter(Mandatory)][hashtable]$MergedCounts,
+        [Parameter(Mandatory)][hashtable]$MergedActivity,
+        [bool]$IncludeActivity,
+        [Parameter(Mandatory)][ref]$TotalFetched
+    )
+    $TotalFetched.Value += $Result.TotalFetched
+    if ($Result.MergerCounts) {
+        foreach ($kv in $Result.MergerCounts.GetEnumerator()) {
+            $MergedCounts[$kv.Key] = ($MergedCounts[$kv.Key] ?? 0) + $kv.Value
+        }
+    }
+    if ($IncludeActivity -and $Result.Activity) {
+        foreach ($kv in $Result.Activity.GetEnumerator()) {
+            $login = $kv.Key
+            $acc = $kv.Value
+            if (-not $MergedActivity.ContainsKey($login)) {
+                $MergedActivity[$login] = @{
+                    paths  = [System.Collections.Generic.List[string]]@()
+                    labels = [System.Collections.Generic.List[string]]@()
+                    count  = 0
+                }
+            }
+            $MergedActivity[$login].count += $acc.count
+            foreach ($p in $acc.paths)  { $MergedActivity[$login].paths.Add($p) }
+            foreach ($l in $acc.labels) { $MergedActivity[$login].labels.Add($l) }
+        }
+    }
+}
+
 # ─── Invoke-ChunkedRepoScan ──────────────────────────────────────────────────
 # Retries a failed repo by splitting the date range into smaller chunks.
 # Returns the same shape as Invoke-RepoMaintainerScan, with partial results
@@ -216,14 +250,16 @@ function Invoke-ChunkedRepoScan {
         [switch]$SkipActivity,
         [string]$DisplayPrefix = '  ',
         [int]$MaxRetries = 5,
-        [ValidateRange(1, 365)][int]$ChunkDays = 7
+        [ValidateRange(1, 365)][int]$ChunkDays = 7,
+        [ValidateRange(1, 365)][int]$MinChunkDays = 1,
+        [string]$EndDate   # optional: limit scan to this date instead of today
     )
 
-    # Compute non-overlapping date ranges from (CutoffDate + 1 day) to today.
+    # Compute non-overlapping date ranges from (CutoffDate + 1 day) to EndDate (or today).
     # The original query uses merged:>CutoffDate (exclusive), so chunks start
     # the day after CutoffDate to preserve semantics.
     $startDate = ([datetime]::Parse($CutoffDate)).AddDays(1)
-    $scanEnd = (Get-Date).Date
+     $scanEnd = if ($EndDate) { [datetime]::Parse($EndDate) } else { (Get-Date).Date }
     if ($startDate -gt $scanEnd) {
         return [PSCustomObject]@{
             Success      = $true
@@ -253,6 +289,7 @@ function Invoke-ChunkedRepoScan {
     $mergedCounts = @{}
     $mergedActivity = @{}
     $totalFetched = 0
+    $anyChunkSucceeded = $false
     $failedChunks = [System.Collections.Generic.List[string]]::new()
 
     foreach ($chunk in $chunks) {
@@ -262,41 +299,39 @@ function Invoke-ChunkedRepoScan {
             -BotLogins $BotLogins -SkipActivity:$SkipActivity -DisplayPrefix "${DisplayPrefix}  " -MaxRetries $MaxRetries
 
         if (-not $scanResult.Success) {
+            # Check the chunk's actual span, not configured ChunkDays, to avoid
+            # redundant recursion on short tail chunks (e.g., a 1-day tail when ChunkDays=7).
+            $actualSpanDays = (([datetime]::Parse($chunk.End)) - ([datetime]::Parse($chunk.Start))).Days + 1
+            if ($actualSpanDays -gt $MinChunkDays) {
+                $subChunkDays = [Math]::Max($MinChunkDays, [Math]::Floor($actualSpanDays / 2))
+                Write-Host "FAILED — sub-chunking to ${subChunkDays}-day ranges" -ForegroundColor Yellow
+                # CutoffDate is chunk.Start minus 1 day because the function adds 1 day back
+                $subCutoff = ([datetime]::Parse($chunk.Start)).AddDays(-1).ToString('yyyy-MM-dd')
+                $subResult = Invoke-ChunkedRepoScan -Repo $Repo -CutoffDate $subCutoff -EndDate $chunk.End `
+                    -BotLogins $BotLogins -SkipActivity:$SkipActivity -DisplayPrefix "${DisplayPrefix}  " `
+                    -MaxRetries $MaxRetries -ChunkDays $subChunkDays -MinChunkDays $MinChunkDays
+
+                # Merge successful sub-chunk results
+                Merge-ScanResult $subResult $mergedCounts $mergedActivity (-not $SkipActivity) ([ref]$totalFetched)
+                # Propagate any sub-chunk failures
+                if ($subResult.FailedChunks) {
+                    foreach ($fc in $subResult.FailedChunks) { $failedChunks.Add($fc) }
+                }
+                if ($subResult.Success) { $anyChunkSucceeded = $true }
+                continue
+            }
+
             Write-Host "FAILED ($($scanResult.Error))" -ForegroundColor Red
             $failedChunks.Add("$($chunk.Start)..$($chunk.End)")
             continue
         }
 
-        $totalFetched += $scanResult.TotalFetched
+        $anyChunkSucceeded = $true
         Write-Host "$($scanResult.TotalFetched) PRs" -ForegroundColor Green
-
-        # Merge MergerCounts (sum by login)
-        if ($scanResult.MergerCounts) {
-            foreach ($kv in $scanResult.MergerCounts.GetEnumerator()) {
-                $mergedCounts[$kv.Key] = ($mergedCounts[$kv.Key] ?? 0) + $kv.Value
-            }
-        }
-
-        # Merge Activity (concatenate paths/labels lists, sum counts)
-        if (-not $SkipActivity -and $scanResult.Activity) {
-            foreach ($kv in $scanResult.Activity.GetEnumerator()) {
-                $login = $kv.Key
-                $acc = $kv.Value
-                if (-not $mergedActivity.ContainsKey($login)) {
-                    $mergedActivity[$login] = @{
-                        paths  = [System.Collections.Generic.List[string]]@()
-                        labels = [System.Collections.Generic.List[string]]@()
-                        count  = 0
-                    }
-                }
-                $mergedActivity[$login].count += $acc.count
-                foreach ($p in $acc.paths)  { $mergedActivity[$login].paths.Add($p) }
-                foreach ($l in $acc.labels) { $mergedActivity[$login].labels.Add($l) }
-            }
-        }
+        Merge-ScanResult $scanResult $mergedCounts $mergedActivity (-not $SkipActivity) ([ref]$totalFetched)
     }
 
-    $anySuccess = ($failedChunks.Count -lt $chunks.Count)
+    $anySuccess = $anyChunkSucceeded
     $errorMsg = ''
     if ($failedChunks.Count -gt 0) {
         $errorMsg = "Failed chunks: $($failedChunks -join ', ')"


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Adaptive sub-chunking for failed API queries

When querying large repos (e.g. `dotnet/dotnet-api-docs`), even 7-day chunks can trigger GitHub 502 errors. This PR adds recursive sub-chunking: when a chunk fails, it halves into smaller ranges (7 to 3 to 1 day) until queries succeed or the minimum granularity is reached.

### How it works

- **Keep what works**: If chunk 1 succeeds and chunk 2 fails, we keep chunk 1's results and only sub-chunk the failed range. No data is discarded or duplicated.
- **Recursive halving**: A failed 7-day chunk splits into ~3-day sub-chunks. If those fail too, they split into 1-day ranges. Only genuinely unrecoverable 1-day failures are reported.
- **Actual-span guard**: Short tail chunks (e.g. a 1-day remainder) won't redundantly recurse -- we check the chunk's actual span, not the configured `ChunkDays`.

### Changes

- Extract `Merge-ScanResult` helper to eliminate duplicated merge logic
- Add `-MinChunkDays` and `-EndDate` params to `Invoke-ChunkedRepoScan`
- Replace count-based success check with `$anyChunkSucceeded` boolean (the old check broke with propagated sub-chunk failures)
- Add 4 new Pester tests for sub-chunking behavior (15 chunked-scan tests total, 141 in suite)

Fixes the remaining 502 failures from #75.
