### PR TITLE
Skip files() in GraphQL for large repos to avoid 502s

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -164,10 +164,17 @@ jobs:
             if [ -f "config/maintainer-activity.json" ]; then
               activity_args="-ActivityFile config/maintainer-activity.json"
             fi
+            # Check if this is a large repo (skip files in GraphQL to avoid 502s)
+            large_repo_flag=""
+            is_large=$(jq -r --arg r "$repo" '.[] | select(.repo == $r) | .largeRepo // false' docs/repos.json 2>/dev/null || echo "false")
+            if [ "$is_large" = "true" ]; then
+              large_repo_flag="-LargeRepo"
+              echo "  (large repo — will skip files in GraphQL)"
+            fi
             # Write scan to temp file; only overwrite scan.json if valid JSON
             scan_ok=true
             scan_stderr="docs/${slug}/scan.stderr.tmp"
-            pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args $prev_scan_args $activity_args -OutputFile "docs/${slug}/scan.json.tmp" 2>"$scan_stderr"
+            pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args $prev_scan_args $activity_args $large_repo_flag -OutputFile "docs/${slug}/scan.json.tmp" 2>"$scan_stderr"
             scan_exit=$?
             if [ $scan_exit -ne 0 ]; then
               echo "::warning::Scan failed for $repo (exit $scan_exit)"

--- a/docs/repos.json
+++ b/docs/repos.json
@@ -33,11 +33,13 @@
   },
   {
     "slug": "dotnet",
-    "repo": "dotnet/dotnet"
+    "repo": "dotnet/dotnet",
+    "largeRepo": true
   },
   {
     "slug": "dotnet-api-docs",
-    "repo": "dotnet/dotnet-api-docs"
+    "repo": "dotnet/dotnet-api-docs",
+    "largeRepo": true
   },
   {
     "slug": "efcore",

--- a/scripts/Build-Index.ps1
+++ b/scripts/Build-Index.ps1
@@ -304,7 +304,19 @@ setInterval(updateTimestamps, 60000);
 $indexHtml | Out-File -FilePath (Join-Path $DocsDir "index.html") -Encoding utf8
 Write-Host "Generated index.html ($($repos.Count) repos)"
 
-# Write repos.json for the cross-repo page
-$reposJson = $repos | ForEach-Object { [ordered]@{ slug = $_.slug; repo = $_.repo } } | ConvertTo-Json
-$reposJson | Out-File -FilePath (Join-Path $DocsDir "repos.json") -Encoding utf8
+# Write repos.json for the cross-repo page, preserving extra fields (e.g., largeRepo) from existing file
+$reposJsonPath = Join-Path $DocsDir "repos.json"
+$existingRepoFlags = @{}
+if (Test-Path $reposJsonPath) {
+    $existingEntries = Get-Content $reposJsonPath -Raw | ConvertFrom-Json
+    foreach ($e in $existingEntries) {
+        if ($e.largeRepo -eq $true) { $existingRepoFlags[$e.repo] = $true }
+    }
+}
+$reposJson = $repos | ForEach-Object {
+    $entry = [ordered]@{ slug = $_.slug; repo = $_.repo }
+    if ($existingRepoFlags.ContainsKey($_.repo)) { $entry['largeRepo'] = $true }
+    $entry
+} | ConvertTo-Json
+$reposJson | Out-File -FilePath $reposJsonPath -Encoding utf8
 Write-Host "Generated repos.json ($($repos.Count) repos)"

--- a/scripts/Build-Index.ps1
+++ b/scripts/Build-Index.ps1
@@ -304,13 +304,17 @@ setInterval(updateTimestamps, 60000);
 $indexHtml | Out-File -FilePath (Join-Path $DocsDir "index.html") -Encoding utf8
 Write-Host "Generated index.html ($($repos.Count) repos)"
 
-# Write repos.json for the cross-repo page, preserving extra fields (e.g., largeRepo) from existing file
+# Write repos.json for the cross-repo page, preserving the existing largeRepo flag when present
 $reposJsonPath = Join-Path $DocsDir "repos.json"
 $existingRepoFlags = @{}
 if (Test-Path $reposJsonPath) {
-    $existingEntries = Get-Content $reposJsonPath -Raw | ConvertFrom-Json
-    foreach ($e in $existingEntries) {
-        if ($e.largeRepo -eq $true) { $existingRepoFlags[$e.repo] = $true }
+    try {
+        $existingEntries = Get-Content $reposJsonPath -Raw | ConvertFrom-Json
+        foreach ($e in $existingEntries) {
+            if ($e.repo -and $e.largeRepo -eq $true) { $existingRepoFlags[$e.repo] = $true }
+        }
+    } catch {
+        Write-Host "::warning::Could not read existing repos.json for flag preservation: $_"
     }
 }
 $reposJson = $repos | ForEach-Object {

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -25,6 +25,11 @@
     This avoids PowerShell stream-leaking issues when stdout is redirected
     by a shell wrapper (Write-Warning and Write-Host leak to stdout when
     pwsh runs as a subprocess). Omit for interactive/local use.
+.PARAMETER LargeRepo
+    When set, omits files(first:100) from the batched GraphQL query. This avoids
+    502 errors on repos whose PRs touch thousands of files (e.g., VMR syncs).
+    CODEOWNERS-based owner resolution and path-based fallback reviewer scoring are
+    unavailable; the script falls back to label-based matching and assigned reviewers.
 .PARAMETER ActivityFile
     Path to maintainer-activity.json, which contains per-maintainer activity signals
     used by the activity-based fallback reviewer selection. When missing or unreadable,
@@ -396,13 +401,20 @@ if ($skipFiles) { Write-Verbose "Skipping files() in GraphQL for $Repo (large re
 $fragment = "number comments(last:20){totalCount nodes{author{login}createdAt}} reviews(last:10){nodes{author{login}state commit{oid}}} reviewRequests(first:10){nodes{requestedReviewer{...on User{login}...on Team{name}}}} reviewThreads(first:50){nodes{isResolved comments(first:5){nodes{author{login}createdAt}}}} commits(last:1){nodes{commit{oid statusCheckRollup{contexts(first:100){pageInfo{hasNextPage endCursor} nodes{...on CheckRun{name conclusion status}}}}}}}" + $filesFragment
 
 $graphqlData = @{}
-$batches = [System.Collections.ArrayList]@()
-$batch = [System.Collections.ArrayList]@()
+# Filter out candidates with invalid PR numbers before batching/scoring
+$validCandidates = [System.Collections.Generic.List[object]]::new()
 foreach ($pr in $refreshCandidates) {
     if (-not $pr.number -or $pr.number -le 0) {
         Write-Warning "Skipping candidate with invalid PR number: $($pr.number)"
         continue
     }
+    [void]$validCandidates.Add($pr)
+}
+$refreshCandidates = $validCandidates
+
+$batches = [System.Collections.ArrayList]@()
+$batch = [System.Collections.ArrayList]@()
+foreach ($pr in $refreshCandidates) {
     [void]$batch.Add($pr.number)
     if ($batch.Count -eq 10) {
         [void]$batches.Add([long[]]$batch.ToArray())

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -63,7 +63,8 @@ param(
     [string]$PreviousScanFile,
     [string]$OutputFile,
     [string]$ActivityFile,
-    [switch]$OutputCsv
+    [switch]$OutputCsv,
+    [switch]$LargeRepo
 )
 
 $ErrorActionPreference = "Stop"
@@ -389,12 +390,19 @@ if ($incrementalEnabled) {
 
 # --- Step 3: Batched GraphQL (reviews, threads, Build Analysis, thread authors, changed files) ---
 # Only fetch details for PRs that need refreshing (all of them if incremental is disabled)
-$fragment = 'number comments(last:20){totalCount nodes{author{login}createdAt}} reviews(last:10){nodes{author{login}state commit{oid}}} reviewRequests(first:10){nodes{requestedReviewer{...on User{login}...on Team{name}}}} reviewThreads(first:50){nodes{isResolved comments(first:5){nodes{author{login}createdAt}}}} commits(last:1){nodes{commit{oid statusCheckRollup{contexts(first:100){pageInfo{hasNextPage endCursor} nodes{...on CheckRun{name conclusion status}}}}}}} files(first:100){nodes{path}}'
+$skipFiles = $LargeRepo
+$filesFragment = if ($skipFiles) { '' } else { ' files(first:100){nodes{path}}' }
+if ($skipFiles) { Write-Verbose "Skipping files() in GraphQL for $Repo (large repo)" }
+$fragment = "number comments(last:20){totalCount nodes{author{login}createdAt}} reviews(last:10){nodes{author{login}state commit{oid}}} reviewRequests(first:10){nodes{requestedReviewer{...on User{login}...on Team{name}}}} reviewThreads(first:50){nodes{isResolved comments(first:5){nodes{author{login}createdAt}}}} commits(last:1){nodes{commit{oid statusCheckRollup{contexts(first:100){pageInfo{hasNextPage endCursor} nodes{...on CheckRun{name conclusion status}}}}}}}" + $filesFragment
 
 $graphqlData = @{}
 $batches = [System.Collections.ArrayList]@()
 $batch = [System.Collections.ArrayList]@()
 foreach ($pr in $refreshCandidates) {
+    if (-not $pr.number -or $pr.number -le 0) {
+        Write-Warning "Skipping candidate with invalid PR number: $($pr.number)"
+        continue
+    }
     [void]$batch.Add($pr.number)
     if ($batch.Count -eq 10) {
         [void]$batches.Add([long[]]$batch.ToArray())

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -380,7 +380,12 @@ $botLogins = @(
 )
 
 $repos = Get-Content $reposJsonPath -Raw | ConvertFrom-Json
-$largeRepos = [System.Collections.Generic.HashSet[string]]@($repos | Where-Object { $_.largeRepo -eq $true } | ForEach-Object { $_.repo })
+$largeRepos = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($r in ($repos | Where-Object { $_.largeRepo -eq $true })) {
+    if ($null -ne $r.repo -and -not [string]::IsNullOrWhiteSpace($r.repo)) {
+        $null = $largeRepos.Add([string]$r.repo)
+    }
+}
 $existing = @{}
 if (Test-Path $maintainersJsonPath) {
     $raw = Get-Content $maintainersJsonPath -Raw | ConvertFrom-Json
@@ -405,7 +410,7 @@ foreach ($entry in $repos) {
     $repo = $entry.repo
     Write-Host "  $repo ... " -NoNewline
 
-    $repoSkipActivity = $SkipActivity -or ($repo -in $largeRepos)
+    $repoSkipActivity = $SkipActivity -or $largeRepos.Contains($repo)
     if ($repoSkipActivity -and -not $SkipActivity) {
         Write-Host "(large repo, skip-activity) " -NoNewline -ForegroundColor DarkGray
     }
@@ -458,8 +463,8 @@ if ($failedRepos.Count -gt 0) {
         $repo = $entry.repo
         Write-Host "  $repo (chunked retry) ..."
 
-        $repoSkipActivity = $SkipActivity -or ($repo -in $largeRepos)
-        $scanResult = Invoke-ChunkedRepoScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$repoSkipActivity -DisplayPrefix '  '
+        $repoSkipActivity = $SkipActivity -or $largeRepos.Contains($repo)
+        $scanResult = Invoke-ChunkedRepoScan-Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$repoSkipActivity -DisplayPrefix '  '
 
         if (-not $scanResult.Success) {
             Write-Host "  ERROR querying $repo on chunked retry (giving up)" -ForegroundColor Red

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -380,6 +380,7 @@ $botLogins = @(
 )
 
 $repos = Get-Content $reposJsonPath -Raw | ConvertFrom-Json
+$largeRepos = [System.Collections.Generic.HashSet[string]]@($repos | Where-Object { $_.largeRepo -eq $true } | ForEach-Object { $_.repo })
 $existing = @{}
 if (Test-Path $maintainersJsonPath) {
     $raw = Get-Content $maintainersJsonPath -Raw | ConvertFrom-Json
@@ -404,7 +405,12 @@ foreach ($entry in $repos) {
     $repo = $entry.repo
     Write-Host "  $repo ... " -NoNewline
 
-    $scanResult = Invoke-RepoMaintainerScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$SkipActivity
+    $repoSkipActivity = $SkipActivity -or ($repo -in $largeRepos)
+    if ($repoSkipActivity -and -not $SkipActivity) {
+        Write-Host "(large repo, skip-activity) " -NoNewline -ForegroundColor DarkGray
+    }
+
+    $scanResult = Invoke-RepoMaintainerScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$repoSkipActivity
 
     if (-not $scanResult.Success) {
         Write-Host "  ERROR querying $repo ($($scanResult.Error)) — queued for retry" -ForegroundColor Red
@@ -414,11 +420,9 @@ foreach ($entry in $repos) {
     }
 
     $mergerCounts = $scanResult.MergerCounts
-    if (-not $SkipActivity) {
+    if (-not $repoSkipActivity) {
         $activityAccum[$repo] = $scanResult.Activity
     }
-
-    # Apply threshold
     $discovered = @($mergerCounts.GetEnumerator() |
         Where-Object { $_.Value -ge $MinMerges } |
         Sort-Object Value -Descending |
@@ -454,7 +458,8 @@ if ($failedRepos.Count -gt 0) {
         $repo = $entry.repo
         Write-Host "  $repo (chunked retry) ..."
 
-        $scanResult = Invoke-ChunkedRepoScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$SkipActivity -DisplayPrefix '  '
+        $repoSkipActivity = $SkipActivity -or ($repo -in $largeRepos)
+        $scanResult = Invoke-ChunkedRepoScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$repoSkipActivity -DisplayPrefix '  '
 
         if (-not $scanResult.Success) {
             Write-Host "  ERROR querying $repo on chunked retry (giving up)" -ForegroundColor Red
@@ -469,7 +474,7 @@ if ($failedRepos.Count -gt 0) {
         }
 
         $mergerCounts = $scanResult.MergerCounts
-        if (-not $SkipActivity) {
+        if (-not $repoSkipActivity) {
             $activityAccum[$repo] = $scanResult.Activity
         }
 

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -464,7 +464,7 @@ if ($failedRepos.Count -gt 0) {
         Write-Host "  $repo (chunked retry) ..."
 
         $repoSkipActivity = $SkipActivity -or $largeRepos.Contains($repo)
-        $scanResult = Invoke-ChunkedRepoScan-Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$repoSkipActivity -DisplayPrefix '  '
+        $scanResult = Invoke-ChunkedRepoScan -Repo $repo -CutoffDate $cutoffDate -BotLogins $botLogins -SkipActivity:$repoSkipActivity -DisplayPrefix '  '
 
         if (-not $scanResult.Success) {
             Write-Host "  ERROR querying $repo on chunked retry (giving up)" -ForegroundColor Red


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with GitHub Copilot CLI.

## Skip `files()` in GraphQL queries for large repos to avoid 502s

### Problem

Both `generate-reports` and `refresh-maintainers` workflows were hitting persistent **HTTP 502** errors when scanning `dotnet/dotnet-api-docs` and `dotnet/dotnet`. The root cause: GitHub's GraphQL server resolves the *full* file list for a PR before truncating to `first: N`. PRs in these repos can touch thousands of files (VMR syncs, "Merge main into live" PRs), causing server-side timeouts even with `first: 10`.

### Fix

**Config-driven `largeRepo` flag** — no repo-specific knowledge hardcoded in scripts:

- **`repos.json`**: Added `"largeRepo": true` to `dotnet/dotnet` and `dotnet/dotnet-api-docs`
- **`Get-PrTriageData.ps1`**: New `-LargeRepo` switch; when set, omits `files(first:100)` from the GraphQL fragment entirely. Also added a guard against PR number 0/null in batch construction (seen in error logs).
- **`Update-Maintainers.ps1`**: Reads `largeRepo` from `repos.json` at startup, builds a HashSet, and passes `-SkipActivity` per-repo instead of using a hardcoded list.
- **`generate-reports.yml`**: Reads `largeRepo` from `repos.json` via `jq` and passes `-LargeRepo` to the script.

### Graceful degradation

When `files()` is skipped, `$changedFilePaths` stays empty (null-safe), CODEOWNERS matching is skipped, and owner assignment falls back to label-based matching and assigned reviewers. The `Select-FallbackReviewers` path-based scoring is also skipped. For maintainers, `-SkipActivity` also skips `labels()`, so `top_area_labels` signals are lost — an accepted quality tradeoff for repos that otherwise can't be scanned at all.

### Testing

All 173 Pester tests pass.
