### PR TITLE
Increase incremental cache TTL from 12h to 36h

### DIFF
--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -109,7 +109,7 @@ try {
     # Return sentinel cache version 0 so it never matches a real cache, ensuring all-refresh.
     function Get-IncrementalCacheVersion { 0 }
     function Import-PreviousScan { param([string]$Path, [int]$RequiredCacheVersion, [string]$Repo = ''); @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null; DisableReason = 'module unavailable' } }
-    function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, [int]$MaxReuseSeconds = 43200); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
+    function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, [int]$MaxReuseSeconds = 129600); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
     function Merge-ReusedEntries { param([hashtable]$ReusedEntries, [array]$PrListData, [array]$Results); $Results }
 }
 $CacheVersion = Get-IncrementalCacheVersion

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -109,7 +109,7 @@ try {
     # Return sentinel cache version 0 so it never matches a real cache, ensuring all-refresh.
     function Get-IncrementalCacheVersion { 0 }
     function Import-PreviousScan { param([string]$Path, [int]$RequiredCacheVersion, [string]$Repo = ''); @{ Enabled = $false; PrLookup = @{}; Fingerprints = @{}; Timestamp = $null; DisableReason = 'module unavailable' } }
-    function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, [int]$MaxReuseSeconds = 129600); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
+    function Get-IncrementalPartition { param([array]$Candidates, [hashtable]$PreviousPrLookup, [hashtable]$PreviousFingerprints, [int]$MaxReuseSeconds = 0); @{ RefreshCandidates = $Candidates; ReusedEntries = @{}; Fallback = $true } }
     function Merge-ReusedEntries { param([hashtable]$ReusedEntries, [array]$PrListData, [array]$Results); $Results }
 }
 $CacheVersion = Get-IncrementalCacheVersion

--- a/scripts/IncrementalScan.psm1
+++ b/scripts/IncrementalScan.psm1
@@ -8,7 +8,8 @@
 $script:CacheVersion = 2
 
 # Max age in seconds before a cached entry is considered stale (used as default for Get-IncrementalPartition).
-$script:MaxReuseSec = 12 * 3600
+# Must exceed the longest schedule interval (standard tier runs ~daily) to allow reuse across runs.
+$script:MaxReuseSec = 36 * 3600
 
 function Get-IncrementalCacheVersion { $script:CacheVersion }
 

--- a/scripts/Tests/IncrementalScan.Tests.ps1
+++ b/scripts/Tests/IncrementalScan.Tests.ps1
@@ -298,7 +298,7 @@ Describe 'Get-IncrementalPartition' {
     }
 
     It 'Refreshes FAILURE CI when TTL expired' {
-        $staleAt = (Get-Date).AddHours(-13).ToString("o")
+        $staleAt = (Get-Date).AddHours(-37).ToString("o")
         $failEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -CI 'FAILURE' -RefreshedAt $staleAt
         $lookup = @{ '10' = $failEntry }
         $fpMap = @{ '10' = $fp1 }
@@ -309,7 +309,7 @@ Describe 'Get-IncrementalPartition' {
     }
 
     It 'Refreshes UNKNOWN mergeable when TTL expired' {
-        $staleAt = (Get-Date).AddHours(-13).ToString("o")
+        $staleAt = (Get-Date).AddHours(-37).ToString("o")
         $unknownEntry = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -Mergeable 'UNKNOWN' -RefreshedAt $staleAt
         $lookup = @{ '10' = $unknownEntry }
         $fpMap = @{ '10' = $fp1 }
@@ -320,7 +320,7 @@ Describe 'Get-IncrementalPartition' {
     }
 
     It 'Force-refreshes when per-PR _refreshed_at exceeds TTL' {
-        $staleAt = (Get-Date).AddHours(-13).ToString("o")
+        $staleAt = (Get-Date).AddHours(-37).ToString("o")
         $staleEntry1 = New-FakeScanEntry -Number 10 -Fingerprint $fp1 -RefreshedAt $staleAt
         $staleEntry2 = New-FakeScanEntry -Number 20 -Fingerprint $fp2 -RefreshedAt $staleAt
         $lookup = @{ '10' = $staleEntry1; '20' = $staleEntry2 }


### PR DESCRIPTION
Standard-tier repos scan ~daily (24h apart), but the incremental cache TTL was 12h — so every cached entry was stale by the next run, resulting in 0% reuse (all PRs re-fetched via GraphQL every time).

Bump TTL from 12h to 36h so it covers the worst-case standard-tier gap with margin. Priority-tier repos (6h intervals) also benefit across consecutive runs.

> [!NOTE]
> This PR was generated with AI assistance (GitHub Copilot).
