### PR TITLE
Harden indexing pipeline resilience

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -172,10 +172,12 @@ jobs:
               echo "  (large repo — will skip files in GraphQL)"
             fi
             # Write scan to temp file; only overwrite scan.json if valid JSON
+            # Use '|| true' so that a failing scan doesn't abort the entire step
+            # (GitHub Actions uses 'set -eo pipefail' by default for bash steps)
             scan_ok=true
             scan_stderr="docs/${slug}/scan.stderr.tmp"
-            pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args $prev_scan_args $activity_args $large_repo_flag -OutputFile "docs/${slug}/scan.json.tmp" 2>"$scan_stderr"
-            scan_exit=$?
+            scan_exit=0
+            pwsh ./scripts/Get-PrTriageData.ps1 -Repo "$repo" -Limit 500 $maintainer_args $prev_scan_args $activity_args $large_repo_flag -OutputFile "docs/${slug}/scan.json.tmp" 2>"$scan_stderr" || scan_exit=$?
             if [ $scan_exit -ne 0 ]; then
               echo "::warning::Scan failed for $repo (exit $scan_exit)"
               if [ -s "$scan_stderr" ]; then

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -172,8 +172,8 @@ jobs:
               echo "  (large repo — will skip files in GraphQL)"
             fi
             # Write scan to temp file; only overwrite scan.json if valid JSON
-            # Use '|| true' so that a failing scan doesn't abort the entire step
-            # (GitHub Actions uses 'set -eo pipefail' by default for bash steps)
+            # Use '|| scan_exit=$?' so that a failing scan captures the exit code
+            # instead of aborting the entire step under 'set -eo pipefail'.
             scan_ok=true
             scan_stderr="docs/${slug}/scan.stderr.tmp"
             scan_exit=0

--- a/scripts/Build-Index.ps1
+++ b/scripts/Build-Index.ps1
@@ -311,7 +311,7 @@ if (Test-Path $reposJsonPath) {
     try {
         $existingEntries = Get-Content $reposJsonPath -Raw | ConvertFrom-Json
         foreach ($e in $existingEntries) {
-            if ($e.repo -and $e.largeRepo -eq $true) { $existingRepoFlags[$e.repo] = $true }
+            if ($e.repo -and $e.PSObject.Properties['largeRepo'] -and $e.largeRepo -eq $true) { $existingRepoFlags[$e.repo] = $true }
         }
     } catch {
         Write-Host "::warning::Could not read existing repos.json for flag preservation: $_"

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -477,7 +477,13 @@ foreach ($prNum in @($graphqlData.Keys)) {
     $allNodes = [System.Collections.ArrayList]@($rollup.contexts.nodes)
     while ($cursor) {
         $q = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { pullRequest(number:$prNum) { commits(last:1) { nodes { commit { statusCheckRollup { contexts(first:100, after:`"$cursor`") { pageInfo { hasNextPage endCursor } nodes { ...on CheckRun { name conclusion status } } } } } } } } } }"
-        $res = (Invoke-GhRetry @("api","graphql","-f","query=$q")) | ConvertFrom-Json
+        try {
+            $raw = Invoke-GhRetry @("api","graphql","-f","query=$q")
+            $res = if ($raw -and -not [string]::IsNullOrWhiteSpace($raw)) { $raw | ConvertFrom-Json } else { $null }
+        } catch {
+            Write-Warning "Failed to paginate checks for PR #${prNum}: $_"
+            break
+        }
         if (-not $res -or -not $res.data -or $res.errors) {
             Write-Warning "Failed to paginate checks for PR #${prNum}: $($res.errors.message -join '; ')"
             break
@@ -529,7 +535,14 @@ if ($prsWithCopilotReview.Count -gt 0) {
             $parts += "pr$($i): pullRequest(number:$($b[$i])) { number reviews(last:5) { nodes { author{login} body } } }"
         }
         $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
-        $result = (Invoke-GhRetry @("api","graphql","-f","query=$query")) | ConvertFrom-Json
+        try {
+            $raw = Invoke-GhRetry @("api","graphql","-f","query=$query")
+            $result = if ($raw -and -not [string]::IsNullOrWhiteSpace($raw)) { $raw | ConvertFrom-Json } else { $null }
+        } catch {
+            Write-Warning "Copilot review check failed for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]: $_"
+            continue
+        }
+        if (-not $result -or -not $result.data -or -not $result.data.repository) { continue }
         for ($i = 0; $i -lt $b.Count; $i++) {
             $prData = $result.data.repository."pr$i"
             if ($prData) {
@@ -565,7 +578,14 @@ if ($copilotAuthoredPRs.Count -gt 0) {
             $parts += "pr$($i): pullRequest(number:$($b[$i])) { number timelineItems(first:5,itemTypes:ASSIGNED_EVENT) { nodes { ... on AssignedEvent { actor{login} assignee{...on User{login}...on Bot{login}} } } } }"
         }
         $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
-        $result = (Invoke-GhRetry @("api","graphql","-f","query=$query")) | ConvertFrom-Json
+        try {
+            $raw = Invoke-GhRetry @("api","graphql","-f","query=$query")
+            $result = if ($raw -and -not [string]::IsNullOrWhiteSpace($raw)) { $raw | ConvertFrom-Json } else { $null }
+        } catch {
+            Write-Warning "Copilot trigger lookup failed for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]: $_"
+            continue
+        }
+        if (-not $result -or -not $result.data -or -not $result.data.repository) { continue }
         for ($i = 0; $i -lt $b.Count; $i++) {
             $prData = $result.data.repository."pr$i"
             if ($prData) {

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -412,11 +412,13 @@ foreach ($pr in $refreshCandidates) {
 }
 $refreshCandidates = $validCandidates
 
+# Use smaller batches for large repos — their PRs tend to have heavier GraphQL payloads
+$batchSize = if ($LargeRepo) { 3 } else { 10 }
 $batches = [System.Collections.ArrayList]@()
 $batch = [System.Collections.ArrayList]@()
 foreach ($pr in $refreshCandidates) {
     [void]$batch.Add($pr.number)
-    if ($batch.Count -eq 10) {
+    if ($batch.Count -eq $batchSize) {
         [void]$batches.Add([long[]]$batch.ToArray())
         $batch = [System.Collections.ArrayList]@()
     }
@@ -427,18 +429,41 @@ $repoParts = $Repo -split '/'
 $repoOwner = $repoParts[0]
 $repoName = $repoParts[1]
 
-Write-Verbose "Fetching details in $($batches.Count) GraphQL batch(es)..."
+Write-Verbose "Fetching details in $($batches.Count) GraphQL batch(es) (batch size: $batchSize)..."
+$batchFailures = 0
 foreach ($b in $batches) {
     $parts = @()
     for ($i = 0; $i -lt $b.Count; $i++) {
         $parts += "pr$($i): pullRequest(number:$($b[$i])) { $fragment }"
     }
     $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
-    $result = (Invoke-GhRetry @("api","graphql","-f","query=$query")) | ConvertFrom-Json
-    for ($i = 0; $i -lt $b.Count; $i++) {
-        $prData = $result.data.repository."pr$i"
-        if ($prData) { $graphqlData[$b[$i]] = $prData }
+    try {
+        $raw = Invoke-GhRetry @("api","graphql","-f","query=$query")
+        if (-not $raw -or [string]::IsNullOrWhiteSpace($raw)) {
+            Write-Warning "Empty GraphQL response for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]"
+            $batchFailures++
+            continue
+        }
+        $result = $raw | ConvertFrom-Json
+        if ($result.errors) {
+            Write-Warning "GraphQL errors for batch: $($result.errors | ForEach-Object { $_.message } | Select-Object -First 3 | Join-String -Separator '; ')"
+        }
+        if (-not $result.data -or -not $result.data.repository) {
+            Write-Warning "No data in GraphQL response for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]"
+            $batchFailures++
+            continue
+        }
+        for ($i = 0; $i -lt $b.Count; $i++) {
+            $prData = $result.data.repository."pr$i"
+            if ($prData) { $graphqlData[$b[$i]] = $prData }
+        }
+    } catch {
+        Write-Warning "GraphQL batch failed for PRs [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]: $_"
+        $batchFailures++
     }
+}
+if ($batchFailures -gt 0) {
+    Write-Warning "$batchFailures of $($batches.Count) GraphQL batches failed — $($graphqlData.Count) PRs have full details"
 }
 
 # Paginate statusCheckRollup contexts for PRs with >100 checks

--- a/scripts/Tests/UpdateMaintainers.Tests.ps1
+++ b/scripts/Tests/UpdateMaintainers.Tests.ps1
@@ -65,3 +65,49 @@ Describe 'Test-MaintainerSafety' {
         $result.Reason | Should -BeLike '*would lose repo keys*'   # key loss reported first
     }
 }
+
+Describe 'largeRepo flag parsing' {
+    It 'Builds HashSet from repos.json with mixed largeRepo presence' {
+        $json = @(
+            [PSCustomObject]@{ slug = 'runtime'; repo = 'dotnet/runtime' }
+            [PSCustomObject]@{ slug = 'dotnet'; repo = 'dotnet/dotnet'; largeRepo = $true }
+            [PSCustomObject]@{ slug = 'aspnetcore'; repo = 'dotnet/aspnetcore' }
+            [PSCustomObject]@{ slug = 'api-docs'; repo = 'dotnet/dotnet-api-docs'; largeRepo = $true }
+        )
+        $largeRepos = [System.Collections.Generic.HashSet[string]]::new()
+        foreach ($r in ($json | Where-Object { $_.PSObject.Properties['largeRepo'] -and $_.largeRepo -eq $true })) {
+            if ($null -ne $r.repo -and -not [string]::IsNullOrWhiteSpace($r.repo)) {
+                $null = $largeRepos.Add([string]$r.repo)
+            }
+        }
+        $largeRepos.Count | Should -Be 2
+        $largeRepos.Contains('dotnet/dotnet') | Should -BeTrue
+        $largeRepos.Contains('dotnet/dotnet-api-docs') | Should -BeTrue
+        $largeRepos.Contains('dotnet/runtime') | Should -BeFalse
+    }
+
+    It 'Handles repos.json with no largeRepo entries' {
+        $json = @(
+            [PSCustomObject]@{ slug = 'runtime'; repo = 'dotnet/runtime' }
+            [PSCustomObject]@{ slug = 'aspnetcore'; repo = 'dotnet/aspnetcore' }
+        )
+        $largeRepos = [System.Collections.Generic.HashSet[string]]::new()
+        foreach ($r in ($json | Where-Object { $_.PSObject.Properties['largeRepo'] -and $_.largeRepo -eq $true })) {
+            $null = $largeRepos.Add([string]$r.repo)
+        }
+        $largeRepos.Count | Should -Be 0
+    }
+
+    It 'Handles largeRepo explicitly set to false' {
+        $json = @(
+            [PSCustomObject]@{ slug = 'runtime'; repo = 'dotnet/runtime'; largeRepo = $false }
+            [PSCustomObject]@{ slug = 'dotnet'; repo = 'dotnet/dotnet'; largeRepo = $true }
+        )
+        $largeRepos = [System.Collections.Generic.HashSet[string]]::new()
+        foreach ($r in ($json | Where-Object { $_.PSObject.Properties['largeRepo'] -and $_.largeRepo -eq $true })) {
+            $null = $largeRepos.Add([string]$r.repo)
+        }
+        $largeRepos.Count | Should -Be 1
+        $largeRepos.Contains('dotnet/dotnet') | Should -BeTrue
+    }
+}

--- a/scripts/Update-Maintainers.ps1
+++ b/scripts/Update-Maintainers.ps1
@@ -381,7 +381,7 @@ $botLogins = @(
 
 $repos = Get-Content $reposJsonPath -Raw | ConvertFrom-Json
 $largeRepos = [System.Collections.Generic.HashSet[string]]::new()
-foreach ($r in ($repos | Where-Object { $_.largeRepo -eq $true })) {
+foreach ($r in ($repos | Where-Object { $_.PSObject.Properties['largeRepo'] -and $_.largeRepo -eq $true })) {
     if ($null -ne $r.repo -and -not [string]::IsNullOrWhiteSpace($r.repo)) {
         $null = $largeRepos.Add([string]$r.repo)
     }


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

## Problem

After merging #84 (large repo 502 fix), CI failed in two ways:
1. **`Property 'largeRepo' cannot be found`** — StrictMode throws when accessing `.largeRepo` on repos.json entries that lack the property
2. **One repo failure kills entire indexing run** — GitHub Actions bash uses `set -eo pipefail`, so when `pwsh` exits non-zero on line 177, bash aborts before reaching `scan_exit=$?`. All subsequent repos never get scanned.
3. **dotnet/dotnet still 502s** on batch GraphQL queries even without `files()` — the fragment payload is too heavy for repos with massive PRs. An unhandled ConvertFrom-Json on empty response kills the scan.

## Fixes

### Workflow resilience (`generate-reports.yml`)
Use `|| scan_exit=$?` pattern so a failing scan captures the exit code instead of aborting the entire step. Other repos continue scanning normally.

### StrictMode guards (`Update-Maintainers.ps1`, `Build-Index.ps1`)
Replace `$_.largeRepo -eq $true` with `$_.PSObject.Properties['largeRepo'] -and $_.largeRepo -eq $true` to safely handle entries without the property.

### Batch GraphQL error handling (`Get-PrTriageData.ps1`)
- Wrap each batch in try/catch — a failing batch logs a warning and continues with remaining batches
- Validate response before accessing `.data.repository`
- Log GraphQL errors from response body
- Track and report batch failure count

### Smaller batches for large repos
Reduce from 10 PRs/batch to 3 for large repos. Their PRs (VMR syncs etc.) have much heavier GraphQL payloads causing server-side timeouts.

### Tests
3 new test cases for largeRepo HashSet construction covering mixed/absent/false property scenarios.

## Testing
All 176 Pester tests pass.
