### PR TITLE
Make GraphQL scanning resilient to 502 errors

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -91,7 +91,7 @@ jobs:
             "dotnet/csharplang:csharplang:standard"
             "dotnet/diagnostics:diagnostics:standard"
             "dotnet/docs:docs:standard"
-            "dotnet/dotnet:dotnet:standard"
+            "dotnet/dotnet:dotnet:standard:allow-fail"
             "dotnet/dotnet-api-docs:dotnet-api-docs:standard"
             "dotnet/efcore:efcore:standard"
             "dotnet/performance:performance:standard"
@@ -108,7 +108,7 @@ jobs:
           scanned_slugs=()  # Track repos that were processed this run (scanned or probe-skipped)
           freshly_scanned=()  # Track repos that were actually rescanned (for rate-limit injection)
           for entry in "${repos[@]}"; do
-            IFS=':' read -r repo slug tier <<< "$entry"
+            IFS=':' read -r repo slug tier failmode <<< "$entry"
 
             # Skip standard-tier repos unless this is the daily slot or manual trigger
             if [ "$tier" = "standard" ] && [ "$RUN_STANDARD" != "true" ]; then
@@ -154,7 +154,7 @@ jobs:
                 # Still run Build-Reports in case templates changed
                 if ! pwsh ./scripts/Build-Reports.ps1 -ScanFile "docs/${slug}/scan.json" -Repo "$repo" -Slug "$slug" -ScheduleDesc "$schedule_desc" -SkipAI; then
                   echo "::warning::Report generation failed for $repo"
-                  failed+=("$repo")
+                  if [ "$failmode" != "allow-fail" ]; then failed+=("$repo"); fi
                 fi
                 continue
               fi
@@ -220,7 +220,7 @@ jobs:
               rm -f "$scan_stderr"
               echo "::warning::Invalid or empty scan output for $repo — keeping previous data"
               rm -f "docs/${slug}/scan.json.tmp"
-              failed+=("$repo")
+              if [ "$failmode" != "allow-fail" ]; then failed+=("$repo"); fi
               if [ ! -f "docs/${slug}/scan.json" ]; then
                 echo "::warning::No previous scan.json for $repo — skipping reports"
                 continue
@@ -230,7 +230,7 @@ jobs:
             freshly_scanned+=("$slug")
             if ! pwsh ./scripts/Build-Reports.ps1 -ScanFile "docs/${slug}/scan.json" -Repo "$repo" -Slug "$slug" -ScheduleDesc "$schedule_desc" -SkipAI; then
               echo "::warning::Report generation failed for $repo"
-              failed+=("$repo")
+              if [ "$failmode" != "allow-fail" ]; then failed+=("$repo"); fi
               continue
             fi
           done

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -439,6 +439,10 @@ foreach ($b in $batches) {
         $failedBatches += ($batches.Count - $batches.IndexOf($b))
         break
     }
+    $parts = @()
+    for ($i = 0; $i -lt $b.Count; $i++) {
+        $parts += "pr$($i): pullRequest(number:$($b[$i])) { $fragment }"
+    }
     $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
     try {
         $raw = Invoke-GhRetry @("api","graphql","-f","query=$query")
@@ -481,9 +485,8 @@ $graphqlCoverage = if ($refreshCandidates.Count -gt 0) { $graphqlData.Count / $r
 if ($refreshCandidates.Count -gt 0 -and $graphqlCoverage -lt 0.5) {
     throw "GraphQL coverage too low for $Repo ($($graphqlData.Count)/$($refreshCandidates.Count) = $([Math]::Round($graphqlCoverage * 100))%) — failing to preserve previous data"
 }
-}
 
-# Paginate statusCheckRollup contexts for PRs with >100 checks
+# Paginate statusCheckRollupcontexts for PRs with >100 checks
 foreach ($prNum in @($graphqlData.Keys)) {
     $gql = $graphqlData[$prNum]
     if (-not $gql -or -not $gql.commits.nodes -or $gql.commits.nodes.Count -eq 0) { continue }

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -430,18 +430,22 @@ $repoOwner = $repoParts[0]
 $repoName = $repoParts[1]
 
 Write-Verbose "Fetching details in $($batches.Count) GraphQL batch(es) (batch size: $batchSize)..."
-$batchFailures = 0
+$failedBatches = 0
+$consecutiveFailures = 0
 foreach ($b in $batches) {
-    $parts = @()
-    for ($i = 0; $i -lt $b.Count; $i++) {
-        $parts += "pr$($i): pullRequest(number:$($b[$i])) { $fragment }"
+    # Circuit breaker: after 2 consecutive batch failures, skip remaining batches
+    if ($consecutiveFailures -ge 2) {
+        Write-Warning "Circuit breaker: skipping remaining $($batches.Count - $batches.IndexOf($b)) batch(es) after $consecutiveFailures consecutive failures"
+        $failedBatches += ($batches.Count - $batches.IndexOf($b))
+        break
     }
     $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
     try {
         $raw = Invoke-GhRetry @("api","graphql","-f","query=$query")
         if (-not $raw -or [string]::IsNullOrWhiteSpace($raw)) {
             Write-Warning "Empty GraphQL response for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]"
-            $batchFailures++
+            $failedBatches++
+            $consecutiveFailures++
             continue
         }
         $result = $raw | ConvertFrom-Json
@@ -450,20 +454,33 @@ foreach ($b in $batches) {
         }
         if (-not $result.data -or -not $result.data.repository) {
             Write-Warning "No data in GraphQL response for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]"
-            $batchFailures++
+            $failedBatches++
+            $consecutiveFailures++
             continue
         }
+        $consecutiveFailures = 0
         for ($i = 0; $i -lt $b.Count; $i++) {
             $prData = $result.data.repository."pr$i"
             if ($prData) { $graphqlData[$b[$i]] = $prData }
         }
     } catch {
         Write-Warning "GraphQL batch failed for PRs [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]: $_"
-        $batchFailures++
+        $failedBatches++
+        $consecutiveFailures++
     }
 }
-if ($batchFailures -gt 0) {
-    Write-Warning "$batchFailures of $($batches.Count) GraphQL batches failed — $($graphqlData.Count) PRs have full details"
+if ($failedBatches -gt 0) {
+    Write-Warning "$failedBatches of $($batches.Count) GraphQL batches failed — $($graphqlData.Count) PRs have full details"
+}
+if ($failedBatches -eq $batches.Count -and $batches.Count -gt 0) {
+    throw "All $($batches.Count) GraphQL batches failed for $Repo — no enrichment data available"
+}
+# Coverage threshold: if <50% of refresh candidates got GraphQL data, the scan
+# quality is too low to trust — fail and preserve previous data
+$graphqlCoverage = if ($refreshCandidates.Count -gt 0) { $graphqlData.Count / $refreshCandidates.Count } else { 1.0 }
+if ($refreshCandidates.Count -gt 0 -and $graphqlCoverage -lt 0.5) {
+    throw "GraphQL coverage too low for $Repo ($($graphqlData.Count)/$($refreshCandidates.Count) = $([Math]::Round($graphqlCoverage * 100))%) — failing to preserve previous data"
+}
 }
 
 # Paginate statusCheckRollup contexts for PRs with >100 checks
@@ -530,31 +547,33 @@ if ($prsWithCopilotReview.Count -gt 0) {
     if ($cb.Count -gt 0) { [void]$copilotBatches.Add([long[]]$cb.ToArray()) }
     Write-Verbose "Checking $($prsWithCopilotReview.Count) PR(s) for Copilot review errors in $($copilotBatches.Count) batch(es)..."
     foreach ($b in $copilotBatches) {
-        $parts = @()
-        for ($i = 0; $i -lt $b.Count; $i++) {
-            $parts += "pr$($i): pullRequest(number:$($b[$i])) { number reviews(last:5) { nodes { author{login} body } } }"
-        }
-        $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
         try {
+            $parts = @()
+            for ($i = 0; $i -lt $b.Count; $i++) {
+                $parts += "pr$($i): pullRequest(number:$($b[$i])) { number reviews(last:5) { nodes { author{login} body } } }"
+            }
+            $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
             $raw = Invoke-GhRetry @("api","graphql","-f","query=$query")
             $result = if ($raw -and -not [string]::IsNullOrWhiteSpace($raw)) { $raw | ConvertFrom-Json } else { $null }
-        } catch {
-            Write-Warning "Copilot review check failed for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]: $_"
-            continue
-        }
-        if (-not $result -or -not $result.data -or -not $result.data.repository) { continue }
-        for ($i = 0; $i -lt $b.Count; $i++) {
-            $prData = $result.data.repository."pr$i"
-            if ($prData) {
-                # Only flag if the MOST RECENT copilot review is an error
-                # (a successful review on a newer commit supersedes an earlier error)
-                $lastCopilotReview = $prData.reviews.nodes |
-                    Where-Object { $_.author.login -eq "copilot-pull-request-reviewer" } |
-                    Select-Object -Last 1
-                if ($lastCopilotReview -and $lastCopilotReview.body -match "Copilot encountered an error") {
-                    $copilotErrorPRs[$b[$i]] = $true
+            if (-not $result -or -not $result.data -or -not $result.data.repository -or $result.errors) {
+                Write-Warning "Copilot review batch returned no data for PRs [$(($b | ForEach-Object { '#' + $_ }) -join ', ')] — skipping"
+                continue
+            }
+            for ($i = 0; $i -lt $b.Count; $i++) {
+                $prData = $result.data.repository."pr$i"
+                if ($prData) {
+                    # Only flag if the MOST RECENT copilot review is an error
+                    # (a successful review on a newer commit supersedes an earlier error)
+                    $lastCopilotReview = $prData.reviews.nodes |
+                        Where-Object { $_.author.login -eq "copilot-pull-request-reviewer" } |
+                        Select-Object -Last 1
+                    if ($lastCopilotReview -and $lastCopilotReview.body -match "Copilot encountered an error") {
+                        $copilotErrorPRs[$b[$i]] = $true
+                    }
                 }
             }
+        } catch {
+            Write-Warning "Copilot review batch failed for PRs $($b -join ','): $_ — skipping"
         }
     }
     Write-Verbose "Found $($copilotErrorPRs.Count) PR(s) with Copilot review errors"
@@ -573,28 +592,30 @@ if ($copilotAuthoredPRs.Count -gt 0) {
     if ($tb.Count -gt 0) { [void]$triggerBatches.Add([long[]]$tb.ToArray()) }
     Write-Verbose "Looking up trigger user for $($copilotAuthoredPRs.Count) Copilot PR(s) in $($triggerBatches.Count) batch(es)..."
     foreach ($b in $triggerBatches) {
-        $parts = @()
-        for ($i = 0; $i -lt $b.Count; $i++) {
-            $parts += "pr$($i): pullRequest(number:$($b[$i])) { number timelineItems(first:5,itemTypes:ASSIGNED_EVENT) { nodes { ... on AssignedEvent { actor{login} assignee{...on User{login}...on Bot{login}} } } } }"
-        }
-        $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
         try {
+            $parts = @()
+            for ($i = 0; $i -lt $b.Count; $i++) {
+                $parts += "pr$($i): pullRequest(number:$($b[$i])) { number timelineItems(first:5,itemTypes:ASSIGNED_EVENT) { nodes { ... on AssignedEvent { actor{login} assignee{...on User{login}...on Bot{login}} } } } }"
+            }
+            $query = "{ repository(owner:`"$repoOwner`",name:`"$repoName`") { $($parts -join ' ') } }"
             $raw = Invoke-GhRetry @("api","graphql","-f","query=$query")
             $result = if ($raw -and -not [string]::IsNullOrWhiteSpace($raw)) { $raw | ConvertFrom-Json } else { $null }
-        } catch {
-            Write-Warning "Copilot trigger lookup failed for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]: $_"
-            continue
-        }
-        if (-not $result -or -not $result.data -or -not $result.data.repository) { continue }
-        for ($i = 0; $i -lt $b.Count; $i++) {
-            $prData = $result.data.repository."pr$i"
-            if ($prData) {
-                $trigger = $prData.timelineItems.nodes |
-                    Where-Object { $_.actor.login -match "copilot-swe-agent" -and $_.assignee.login -and $_.assignee.login -notmatch "^(app/)?copilot-swe-agent$|^Copilot$" } |
-                    Select-Object -First 1 -ExpandProperty assignee |
-                    Select-Object -ExpandProperty login -ErrorAction SilentlyContinue
-                if ($trigger) { $copilotTriggers[$b[$i]] = $trigger }
+            if (-not $result -or -not $result.data -or -not $result.data.repository -or $result.errors) {
+                Write-Warning "Copilot trigger batch returned no data for PRs [$(($b | ForEach-Object { '#' + $_ }) -join ', ')] — skipping"
+                continue
             }
+            for ($i = 0; $i -lt $b.Count; $i++) {
+                $prData = $result.data.repository."pr$i"
+                if ($prData) {
+                    $trigger = $prData.timelineItems.nodes |
+                        Where-Object { $_.actor.login -match "copilot-swe-agent" -and $_.assignee.login -and $_.assignee.login -notmatch "^(app/)?copilot-swe-agent$|^Copilot$" } |
+                        Select-Object -First 1 -ExpandProperty assignee |
+                        Select-Object -ExpandProperty login -ErrorAction SilentlyContinue
+                    if ($trigger) { $copilotTriggers[$b[$i]] = $trigger }
+                }
+            }
+        } catch {
+            Write-Warning "Copilot trigger batch failed for PRs [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]: $_"
         }
     }
     Write-Verbose "Found trigger user for $($copilotTriggers.Count) of $($copilotAuthoredPRs.Count) Copilot PR(s)"
@@ -1400,6 +1421,8 @@ $output = @{
         reused = $reusedPrEntries.Count
         full_scan = (-not $incrementalEnabled -or $incrementalFallback)
         fallback = $incrementalFallback
+        graphql_failed_batches = $failedBatches
+        graphql_total_batches = $batches.Count
     }
     owners = $owners
     scanned = $prsRaw.Count

--- a/scripts/Get-PrTriageData.ps1
+++ b/scripts/Get-PrTriageData.ps1
@@ -454,7 +454,7 @@ foreach ($b in $batches) {
         }
         $result = $raw | ConvertFrom-Json
         if ($result.errors) {
-            Write-Warning "GraphQL errors for batch: $($result.errors | ForEach-Object { $_.message } | Select-Object -First 3 | Join-String -Separator '; ')"
+            Write-Warning "GraphQL errors for batch: $((@($result.errors | ForEach-Object { $_.message } | Select-Object -First 3)) -join '; ')"
         }
         if (-not $result.data -or -not $result.data.repository) {
             Write-Warning "No data in GraphQL response for batch [$(($b | ForEach-Object { '#' + $_ }) -join ', ')]"
@@ -486,7 +486,7 @@ if ($refreshCandidates.Count -gt 0 -and $graphqlCoverage -lt 0.5) {
     throw "GraphQL coverage too low for $Repo ($($graphqlData.Count)/$($refreshCandidates.Count) = $([Math]::Round($graphqlCoverage * 100))%) — failing to preserve previous data"
 }
 
-# Paginate statusCheckRollupcontexts for PRs with >100 checks
+# Paginate statusCheckRollup contexts for PRs with >100 checks
 foreach ($prNum in @($graphqlData.Keys)) {
     $gql = $graphqlData[$prNum]
     if (-not $gql -or -not $gql.commits.nodes -or $gql.commits.nodes.Count -eq 0) { continue }


### PR DESCRIPTION
## Make GraphQL scanning resilient to 502 errors

Two recent CI runs ([24624058876](https://github.com/danmoseley/pr-dashboard/actions/runs/24624058876), [24599738384](https://github.com/danmoseley/pr-dashboard/actions/runs/24599738384)) failed because `dotnet/dotnet` GraphQL queries consistently returned HTTP 502, crashing the entire scan job.

### Changes

**`scripts/Get-PrTriageData.ps1`:**
- **Circuit breaker**: After 2 consecutive batch failures, skip remaining batches (avoids 26+ min retry waits per batch)
- **Coverage threshold**: If <50% of refresh candidates got GraphQL data, fail the scan to preserve previous good data
- **`$result.errors` checks**: All 3 batch loops (main, copilot review, copilot trigger) now check for GraphQL-level errors in addition to null data
- **Metadata**: Output includes `graphql_failed_batches` / `graphql_total_batches` for observability

**`.github/workflows/generate-reports.yml`:**
- **Allow-fail tier**: `dotnet/dotnet` marked as `allow-fail` — its scan failures no longer fail the entire job
- **Parsing**: Entry format extended to `repo:slug:tier:failmode` (backward-compatible; 3-field entries work unchanged)
- **Gating**: All 3 `failed+=("$repo")` sites skip repos with `failmode=allow-fail`

### Root cause

`dotnet/dotnet` has ~60 open PRs. GraphQL batched detail queries returned HTTP 502 consistently. `Invoke-GhRetry` retried 4× with 60/300/1200s backoff (~26 min per batch). The error text was parsed as JSON, producing an object without `.data.repository`, causing a null index error that propagated up as a scan failure.
