### PR TITLE
Improve narrow display: non-proportional column shrinking, column chooser, drag-resize fix

### DIFF
--- a/docs/_test_shrink.html
+++ b/docs/_test_shrink.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html><head>
+<link rel="stylesheet" href="shared-styles.css">
+<style>table#pr-table { table-layout: fixed; }</style>
+</head><body>
+<table id="pr-table">
+<colgroup>
+  <col data-col="ready"><col data-col="need"><col data-col="action">
+  <col data-col="pr"><col data-col="repo">
+  <col data-col="title"><col data-col="nextaction">
+  <col data-col="ci"><col data-col="disc">
+  <col data-col="age"><col data-col="upd"><col data-col="size">
+  <col data-col="author"><col data-col="area">
+</colgroup>
+<thead><tr>
+  <th data-col="ready">Rdy</th><th data-col="need">Need</th><th data-col="action">Act</th>
+  <th data-col="pr">PR</th><th data-col="repo">Repo</th>
+  <th data-col="title">Title</th><th data-col="nextaction">Next Action</th>
+  <th data-col="ci">CI</th><th data-col="disc">Disc</th>
+  <th data-col="age">Age</th><th data-col="upd">Upd</th><th data-col="size">Size</th>
+  <th data-col="author">Author</th><th data-col="area">Area</th>
+</tr></thead>
+<tbody>
+<tr>
+  <td data-col="ready">3</td><td data-col="need">1</td><td data-col="action">2</td>
+  <td data-col="pr">#4821</td><td data-col="repo">runtime</td>
+  <td data-col="title">Fix regex perf regression in backtracking</td>
+  <td data-col="nextaction">Waiting on CI results</td>
+  <td data-col="ci">ok</td><td data-col="disc">5</td>
+  <td data-col="age">3d</td><td data-col="upd">1h</td><td data-col="size">M</td>
+  <td data-col="author">danmose</td><td data-col="area">regex</td>
+</tr>
+</tbody>
+</table>
+</body></html>

--- a/docs/actionable.html
+++ b/docs/actionable.html
@@ -1178,35 +1178,35 @@
     var smallPrThreshold = smallPrEnabled ? sortedLines[Math.floor((sortedLines.length - 1) * 0.10)] : 0;
 
     var html = '<table id="pr-table"><colgroup>' +
-      '<col style="width:2.5%">' +     // Ready
-      '<col style="width:2.5%">' +     // Need
-      '<col style="width:2.5%">' +     // Action
-      '<col style="width:3.5%">' +    // PR
-      '<col style="width:6%">' +      // Repo
-      '<col>' +                       // Title (flex)
-      '<col style="width:25%">' +     // Next Action
-      '<col style="width:6%">' +      // CI
-      '<col style="width:3%">' +      // Disc
-      '<col style="width:2.5%">' +    // Age
-      '<col style="width:2.5%">' +    // Upd
-      '<col style="width:2.5%">' +    // Size
-      '<col style="width:8%">' +      // Author
-      (hasArea ? '<col style="width:7%">' : '') +
+      '<col data-col="ready" style="width:2.5%">' +
+      '<col data-col="need" style="width:2.5%">' +
+      '<col data-col="action" style="width:2.5%">' +
+      '<col data-col="pr" style="width:3.5%">' +
+      '<col data-col="repo" style="width:6%">' +
+      '<col data-col="title">' +
+      '<col data-col="nextaction" style="width:25%">' +
+      '<col data-col="ci" style="width:6%">' +
+      '<col data-col="disc" style="width:3%">' +
+      '<col data-col="age" style="width:2.5%">' +
+      '<col data-col="upd" style="width:2.5%">' +
+      '<col data-col="size" style="width:2.5%">' +
+      '<col data-col="author" style="width:8%">' +
+      (hasArea ? '<col data-col="area" style="width:7%">' : '') +
       '</colgroup><thead><tr>' +
-      '<th class="sortable" data-sort="num" title="Ready: how close is this PR to being mergeable? Based on CI, approvals, conflicts, size, etc.">Ready</th>' +
-      '<th class="sortable" data-sort="num" title="Need: how much does this PR benefit from maintainer attention? Community PRs, stalled feedback, missing approvals score higher.">Need</th>' +
-      '<th class="sortable action-col" data-sort="num" title="Action: combined score = (ready+1) x (need+1), normalized 0-10. PRs that are both high-need and near-ready rank highest.">Action</th>' +
-      '<th class="sortable" data-sort="num" title="Pull request number">PR</th>' +
-      '<th class="sortable" data-sort="alpha" title="Repository">Repo</th>' +
-      '<th class="sortable" data-sort="alpha" title="PR title and labels">Title</th>' +
-      '<th class="sortable" data-sort="alpha" title="Who needs to act next and what they should do">Next Action</th>' +
-      '<th title="CI status from Build Analysis (or latest check run)">CI</th>' +
-      '<th class="sortable" data-sort="num" title="Discussion: unresolved/total review threads and distinct commenters">Disc</th>' +
-      '<th class="sortable" data-sort="num" title="Age in days since PR was opened">Age</th>' +
-      '<th class="sortable" data-sort="num" title="Days since last update (push, comment, or review)">Upd</th>' +
-      '<th class="sortable" data-sort="num" title="Total lines changed (additions + deletions). &#x1F401; = smallest 10%">Size</th>' +
-      '<th class="sortable" data-sort="alpha" title="PR author">Author</th>' +
-      (hasArea ? '<th class="sortable" data-sort="alpha" title="Area labels assigned to this PR">Area</th>' : '') +
+      '<th data-col="ready" class="sortable" data-sort="num" title="Ready: how close is this PR to being mergeable? Based on CI, approvals, conflicts, size, etc.">Ready</th>' +
+      '<th data-col="need" class="sortable" data-sort="num" title="Need: how much does this PR benefit from maintainer attention? Community PRs, stalled feedback, missing approvals score higher.">Need</th>' +
+      '<th data-col="action" class="sortable action-col" data-sort="num" title="Action: combined score = (ready+1) x (need+1), normalized 0-10. PRs that are both high-need and near-ready rank highest.">Action</th>' +
+      '<th data-col="pr" class="sortable" data-sort="num" title="Pull request number">PR</th>' +
+      '<th data-col="repo" class="sortable" data-sort="alpha" title="Repository">Repo</th>' +
+      '<th data-col="title" class="sortable" data-sort="alpha" title="PR title and labels">Title</th>' +
+      '<th data-col="nextaction" class="sortable" data-sort="alpha" title="Who needs to act next and what they should do">Next Action</th>' +
+      '<th data-col="ci" title="CI status from Build Analysis (or latest check run)">CI</th>' +
+      '<th data-col="disc" class="sortable" data-sort="num" title="Discussion: unresolved/total review threads and distinct commenters">Disc</th>' +
+      '<th data-col="age" class="sortable" data-sort="num" title="Age in days since PR was opened">Age</th>' +
+      '<th data-col="upd" class="sortable" data-sort="num" title="Days since last update (push, comment, or review)">Upd</th>' +
+      '<th data-col="size" class="sortable" data-sort="num" title="Total lines changed (additions + deletions). &#x1F401; = smallest 10%">Size</th>' +
+      '<th data-col="author" class="sortable" data-sort="alpha" title="PR author">Author</th>' +
+      (hasArea ? '<th data-col="area" class="sortable" data-sort="alpha" title="Area labels assigned to this PR">Area</th>' : '') +
       '</tr></thead><tbody>';
 
     for (var i = 0; i < prs.length; i++) {
@@ -1235,6 +1235,7 @@
     // Wire up sortable column headers (Action = column 2)
     initTableSort('pr-table', 2);
     initResizableColumns('pr-table');
+    initColumnChooser('pr-table');
 
     // Apply any active secondary filters from URL state
     if (activeAreas.length > 0 || activeRepos.length > 0) {
@@ -1343,20 +1344,20 @@
     var unknownScore = '<span style="color:#8b949e">?</span>';
 
     return '<tr' + moreClass + ' data-repo="' + safeSlug + '" data-people="' + escAttr(people) + '" data-involved="' + escAttr(involved) + '" data-labels="' + escAttr(labels) + '">' +
-      '<td class="score' + readyClass + '">' + (isNewlyDiscovered ? unknownScore : readyVal + '<button type="button" class="why-btn" onclick="showWhy(this)" data-why="' + escAttr(safeWhy) + '" aria-label="Show Ready score breakdown">?</button>') + '</td>' +
-      '<td class="score">' + (isNewlyDiscovered ? unknownScore : needVal + '<button type="button" class="why-btn" onclick="showWhy(this)" data-why="' + escAttr(safeValueWhy) + '" aria-label="Show Need score breakdown">?</button>') + '</td>' +
-      '<td class="action-score' + actionClass + '">' + (isNewlyDiscovered ? unknownScore : actionEmoji2 + actionVal + '<button type="button" class="why-btn action-why-btn" onclick="showWhy(this)" data-why="' + escAttr(safeActionWhy) + '" aria-label="Show Action score breakdown">?</button>') + '</td>' +
-      '<td class="pr-num"><a href="' + prUrl + '" title="' + escAttr(pr.title || '') + '">#' + pr.number + '</a></td>' +
-      '<td class="repo-col"><button type="button" class="repo-filter-btn" onclick="filterByRepo(event,\'' + safeSlugJs + '\')" title="Filter to ' + escAttr(pr._slug) + ' (Ctrl+click to add)">' + escHtml(pr._slug) + '</button><a class="filter-btn" href="#" onclick="filterByRepo(event,\'' + safeSlugJs + '\');return false" title="Filter to ' + escAttr(pr._slug) + ' (Ctrl+click to add)" aria-label="Filter to ' + escAttr(pr._slug) + '">&#x1F50D;</a></td>' +
-      '<td class="title">' + easyBadge + safeTitle + '</td>' +
-      '<td class="action" title="' + escAttr(pr.blockers || '') + '">' + (isNewlyDiscovered ? unknownCell : (isYourTurn ? '<span class="your-turn-badge" title="Your turn to act">&#x1F449; </span>' : '') + actionEmoji + convertUserRefs(escHtml(na)) + (pr.who_why ? '<button type="button" class="why-btn" onclick="showWhy(this)" data-why="' + escAttr(pr.who_why) + '" aria-label="Why these people?">?</button>' : '')) + '</td>' +
-      '<td class="ci"' + ciTitle + '>' + (isNewlyDiscovered && pr.ci === 'UNKNOWN' ? unknownCell : ciEmoji + ciFailHint + ' ' + (pr.ci_detail || '')) + '</td>' +
-      '<td class="disc' + discHeat + '">' + (isNewlyDiscovered ? unknownCell : discEmoji + (pr.unresolved_threads || 0) + '/' + (pr.total_threads || 0) + 't ' + (pr.distinct_commenters || 0) + 'p<button type="button" class="why-btn" onclick="showWhy(this)" data-why="' + escAttr((pr.unresolved_threads || 0) + ' unresolved / ' + (pr.total_threads || 0) + ' total threads\n' + (pr.distinct_commenters || 0) + ' distinct commenters') + '" aria-label="Show discussion details">?</button>') + '</td>' +
-      '<td class="num' + ageHeat + '">' + (pr.age_days || 0) + 'd</td>' +
-      '<td class="num' + updateHeat + '">' + (pr.days_since_update || 0) + 'd</td>' +
-      '<td class="num' + filesHeat + '" title="' + (pr.changed_files || 0) + ' ' + ((pr.changed_files || 0) === 1 ? 'file' : 'files') + ', ' + linesChanged + ' ' + (linesChanged === 1 ? 'line' : 'lines') + ' (additions + deletions)">' + sizeIcon + linesChanged + '</td>' +
-      '<td class="author">' + communityBadge + authorHtml + '</td>' +
-      (hasArea ? '<td class="area-col">' + areaHtml + '</td>' : '') +
+      '<td data-col="ready" class="score' + readyClass + '">' + (isNewlyDiscovered ? unknownScore : readyVal + '<button type="button" class="why-btn" onclick="showWhy(this)" data-why="' + escAttr(safeWhy) + '" aria-label="Show Ready score breakdown">?</button>') + '</td>' +
+      '<td data-col="need" class="score">' + (isNewlyDiscovered ? unknownScore : needVal + '<button type="button" class="why-btn" onclick="showWhy(this)" data-why="' + escAttr(safeValueWhy) + '" aria-label="Show Need score breakdown">?</button>') + '</td>' +
+      '<td data-col="action" class="action-score' + actionClass + '">' + (isNewlyDiscovered ? unknownScore : actionEmoji2 + actionVal + '<button type="button" class="why-btn action-why-btn" onclick="showWhy(this)" data-why="' + escAttr(safeActionWhy) + '" aria-label="Show Action score breakdown">?</button>') + '</td>' +
+      '<td data-col="pr" class="pr-num"><a href="' + prUrl + '" title="' + escAttr(pr.title || '') + '">#' + pr.number + '</a></td>' +
+      '<td data-col="repo" class="repo-col"><button type="button" class="repo-filter-btn" onclick="filterByRepo(event,\'' + safeSlugJs + '\')" title="Filter to ' + escAttr(pr._slug) + ' (Ctrl+click to add)">' + escHtml(pr._slug) + '</button><a class="filter-btn" href="#" onclick="filterByRepo(event,\'' + safeSlugJs + '\');return false" title="Filter to ' + escAttr(pr._slug) + ' (Ctrl+click to add)" aria-label="Filter to ' + escAttr(pr._slug) + '">&#x1F50D;</a></td>' +
+      '<td data-col="title" class="title">' + easyBadge + safeTitle + '</td>' +
+      '<td data-col="nextaction" class="action" title="' + escAttr(pr.blockers || '') + '">' + (isNewlyDiscovered ? unknownCell : (isYourTurn ? '<span class="your-turn-badge" title="Your turn to act">&#x1F449; </span>' : '') + actionEmoji + convertUserRefs(escHtml(na)) + (pr.who_why ? '<button type="button" class="why-btn" onclick="showWhy(this)" data-why="' + escAttr(pr.who_why) + '" aria-label="Why these people?">?</button>' : '')) + '</td>' +
+      '<td data-col="ci" class="ci"' + ciTitle + '>' + (isNewlyDiscovered && pr.ci === 'UNKNOWN' ? unknownCell : ciEmoji + ciFailHint + ' ' + (pr.ci_detail || '')) + '</td>' +
+      '<td data-col="disc" class="disc' + discHeat + '">' + (isNewlyDiscovered ? unknownCell : discEmoji + (pr.unresolved_threads || 0) + '/' + (pr.total_threads || 0) + 't ' + (pr.distinct_commenters || 0) + 'p<button type="button" class="why-btn" onclick="showWhy(this)" data-why="' + escAttr((pr.unresolved_threads || 0) + ' unresolved / ' + (pr.total_threads || 0) + ' total threads\n' + (pr.distinct_commenters || 0) + ' distinct commenters') + '" aria-label="Show discussion details">?</button>') + '</td>' +
+      '<td data-col="age" class="num' + ageHeat + '">' + (pr.age_days || 0) + 'd</td>' +
+      '<td data-col="upd" class="num' + updateHeat + '">' + (pr.days_since_update || 0) + 'd</td>' +
+      '<td data-col="size" class="num' + filesHeat + '" title="' + (pr.changed_files || 0) + ' ' + ((pr.changed_files || 0) === 1 ? 'file' : 'files') + ', ' + linesChanged + ' ' + (linesChanged === 1 ? 'line' : 'lines') + ' (additions + deletions)">' + sizeIcon + linesChanged + '</td>' +
+      '<td data-col="author" class="author">' + communityBadge + authorHtml + '</td>' +
+      (hasArea ? '<td data-col="area" class="area-col">' + areaHtml + '</td>' : '') +
       '</tr>';
   }
 

--- a/docs/actionable.html
+++ b/docs/actionable.html
@@ -12,9 +12,9 @@
     border-radius: 6px; padding: 3px 10px; font-size: 0.85em; width: 220px; }
   .user-input input[type="text"]::placeholder { color: #484f58; }
   .user-input input[type="text"]:focus { outline: none; border-color: var(--link); }
-  .user-input > button { background: #238636; color: #fff; border: none; border-radius: 6px;
+  #go-btn { background: #238636; color: #fff; border: none; border-radius: 6px;
     padding: 3px 12px; font-size: 0.85em; cursor: pointer; font-weight: 500; }
-  .user-input > button:hover { background: #2ea043; }
+  #go-btn:hover { background: #2ea043; }
   .clear-user-btn { background: none !important; border: 1px solid var(--border) !important;
     color: #8b949e !important; padding: 3px 8px !important; font-size: 0.85em !important;
     font-weight: normal !important; line-height: 1; }
@@ -52,7 +52,7 @@
 <p class="meta">Cross-repo view of actionable PRs across all tracked dotnet repositories</p>
 <p class="meta" id="meta-line"></p>
 
-<div class="user-input">
+<div class="user-input" id="user-input-row">
   <input type="text" id="user-field" placeholder="GitHub username (e.g. danmoseley)" autocomplete="off" spellcheck="false">
   <button id="go-btn" onclick="applyUser()">Go</button>
   <button id="clear-user-btn" class="clear-user-btn" onclick="clearUserOnly()" aria-label="Clear user filter" style="display:none"><span aria-hidden="true">&#x2715;</span></button>
@@ -1178,20 +1178,20 @@
     var smallPrThreshold = smallPrEnabled ? sortedLines[Math.floor((sortedLines.length - 1) * 0.10)] : 0;
 
     var html = '<table id="pr-table"><colgroup>' +
-      '<col data-col="ready" style="width:2.5%">' +
-      '<col data-col="need" style="width:2.5%">' +
-      '<col data-col="action" style="width:2.5%">' +
-      '<col data-col="pr" style="width:3.5%">' +
-      '<col data-col="repo" style="width:6%">' +
+      '<col data-col="ready">' +
+      '<col data-col="need">' +
+      '<col data-col="action">' +
+      '<col data-col="pr">' +
+      '<col data-col="repo">' +
       '<col data-col="title">' +
-      '<col data-col="nextaction" style="width:25%">' +
-      '<col data-col="ci" style="width:6%">' +
-      '<col data-col="disc" style="width:3%">' +
-      '<col data-col="age" style="width:2.5%">' +
-      '<col data-col="upd" style="width:2.5%">' +
-      '<col data-col="size" style="width:2.5%">' +
-      '<col data-col="author" style="width:8%">' +
-      (hasArea ? '<col data-col="area" style="width:7%">' : '') +
+      '<col data-col="nextaction">' +
+      '<col data-col="ci">' +
+      '<col data-col="disc">' +
+      '<col data-col="age">' +
+      '<col data-col="upd">' +
+      '<col data-col="size">' +
+      '<col data-col="author">' +
+      (hasArea ? '<col data-col="area">' : '') +
       '</colgroup><thead><tr>' +
       '<th data-col="ready" class="sortable" data-sort="num" title="Ready: how close is this PR to being mergeable? Based on CI, approvals, conflicts, size, etc.">Ready</th>' +
       '<th data-col="need" class="sortable" data-sort="num" title="Need: how much does this PR benefit from maintainer attention? Community PRs, stalled feedback, missing approvals score higher.">Need</th>' +
@@ -1235,7 +1235,7 @@
     // Wire up sortable column headers (Action = column 2)
     initTableSort('pr-table', 2);
     initResizableColumns('pr-table');
-    initColumnChooser('pr-table');
+    initColumnChooser('pr-table', null, 'user-input-row');
 
     // Apply any active secondary filters from URL state
     if (activeAreas.length > 0 || activeRepos.length > 0) {

--- a/docs/shared-styles.css
+++ b/docs/shared-styles.css
@@ -99,58 +99,49 @@ col[data-col="size"]   { width: 2.5%; }
 col[data-col="author"] { width: 8%; }
 col[data-col="area"]   { width: 7%; }
 
-/* Medium-narrow: squeeze collapse-first columns, give space to content columns */
+/* Tier 1 (≤1200px): numbers vanish immediately, disc/age/upd/size shrink fast */
 @media (max-width: 1200px) {
-  col[data-col="ready"]  { width: 1.5%; }
-  col[data-col="need"]   { width: 1.5%; }
-  col[data-col="action"] { width: 2%; }
-  col[data-col="disc"]   { width: 1.5%; }
-  col[data-col="age"]    { width: 1.5%; }
-  col[data-col="upd"]    { width: 1.5%; }
-  col[data-col="size"]   { width: 1.5%; }
-  col[data-col="ci"]     { width: 3%; }
-  col[data-col="repo"]   { width: 4%; }
-  col[data-col="author"] { width: 5%; }
-  col[data-col="area"]   { width: 5%; }
-}
-
-/* Narrow: collapse-first columns nearly vanish */
-@media (max-width: 900px) {
-  col[data-col="ready"]  { width: 0.5%; }
-  col[data-col="need"]   { width: 0.5%; }
-  col[data-col="action"] { width: 1%; }
-  col[data-col="disc"]   { width: 0.5%; }
-  col[data-col="age"]    { width: 0.5%; }
-  col[data-col="upd"]    { width: 0.5%; }
-  col[data-col="size"]   { width: 1%; }
-  col[data-col="ci"]     { width: 2%; }
-  col[data-col="repo"]   { width: 2.5%; }
-  col[data-col="pr"]     { width: 2.5%; }
-  col[data-col="author"] { width: 4%; }
-  col[data-col="area"]   { width: 3%; }
-  col[data-col="nextaction"] { width: 20%; }
-}
-
-/* Very narrow: collapse-first columns hidden, minimal widths for remaining */
-@media (max-width: 650px) {
   col[data-col="ready"]  { width: 0; }
   col[data-col="need"]   { width: 0; }
+  col[data-col="action"] { width: 0; }
+  col[data-col="disc"]   { width: 1%; }
+  col[data-col="age"]    { width: 1%; }
+  col[data-col="upd"]    { width: 1%; }
+  col[data-col="size"]   { width: 1%; }
+  col[data-col="ci"]     { width: 2.5%; }
+  col[data-col="repo"]   { width: 5%; }
+  col[data-col="author"] { width: 6%; }
+  col[data-col="area"]   { width: 5%; }
+  td[data-col="ready"], th[data-col="ready"],
+  td[data-col="need"], th[data-col="need"],
+  td[data-col="action"], th[data-col="action"] { font-size: 0; padding: 0; border: 0; }
+}
+
+/* Tier 2 (≤900px): disc/age/upd/size vanish, CI to icon width, area/author squeeze */
+@media (max-width: 900px) {
   col[data-col="disc"]   { width: 0; }
   col[data-col="age"]    { width: 0; }
   col[data-col="upd"]    { width: 0; }
-  col[data-col="action"] { width: 0.5%; }
-  col[data-col="size"]   { width: 0.5%; }
+  col[data-col="size"]   { width: 0; }
   col[data-col="ci"]     { width: 1.5%; }
-  col[data-col="repo"]   { width: 2%; }
-  col[data-col="pr"]     { width: 2%; }
-  col[data-col="author"] { width: 3%; }
-  col[data-col="area"]   { width: 0; }
-  col[data-col="nextaction"] { width: 15%; }
-  td[data-col="ready"], th[data-col="ready"],
-  td[data-col="need"], th[data-col="need"],
+  col[data-col="repo"]   { width: 4%; }
+  col[data-col="pr"]     { width: 3%; }
+  col[data-col="author"] { width: 4%; }
+  col[data-col="area"]   { width: 3%; }
   td[data-col="disc"], th[data-col="disc"],
   td[data-col="age"], th[data-col="age"],
   td[data-col="upd"], th[data-col="upd"],
+  td[data-col="size"], th[data-col="size"] { font-size: 0; padding: 0; border: 0; }
+}
+
+/* Tier 3 (≤650px): area/author vanish, CI/repo/PR minimal, max space to title+nextaction */
+@media (max-width: 650px) {
+  col[data-col="ci"]     { width: 1%; }
+  col[data-col="repo"]   { width: 3%; }
+  col[data-col="pr"]     { width: 2.5%; }
+  col[data-col="author"] { width: 0; }
+  col[data-col="area"]   { width: 0; }
+  td[data-col="author"], th[data-col="author"],
   td[data-col="area"], th[data-col="area"] { font-size: 0; padding: 0; border: 0; }
 }
 

--- a/docs/shared-styles.css
+++ b/docs/shared-styles.css
@@ -35,13 +35,13 @@ th {
 td { padding: 5px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
 tr:hover { background: var(--hover); }
 
-/* Score cells */
-.score { font-weight: bold; text-align: right; white-space: nowrap; font-size: 0.95em; position: relative; }
+/* Score cells - can collapse to nothing at narrow widths */
+.score { font-weight: bold; text-align: right; white-space: nowrap; font-size: 0.95em; position: relative; overflow: hidden; }
 .ready-high { background: rgba(35, 134, 54, 0.12); }
 .action-score {
   font-weight: 800; text-align: right; white-space: nowrap; font-size: 1.25em; color: #f0c674;
   background: rgba(240, 198, 116, 0.08); border-left: 2px solid rgba(240, 198, 116, 0.3);
-  border-right: 2px solid rgba(240, 198, 116, 0.3); position: relative;
+  border-right: 2px solid rgba(240, 198, 116, 0.3); position: relative; overflow: hidden;
 }
 .action-hot { background: rgba(35, 134, 54, 0.18); border-color: rgba(35, 134, 54, 0.4); }
 .action-warm { background: rgba(35, 134, 54, 0.08); border-color: rgba(35, 134, 54, 0.2); }
@@ -68,15 +68,34 @@ th.sortable:hover { color: var(--link); }
 th.sorted { color: var(--link); }
 
 /* PR table cells */
-.pr-num { white-space: nowrap; }
-.title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.area-col { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.action { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.ci { white-space: nowrap; padding: 5px 4px; }
+.pr-num { white-space: nowrap; min-width: 35px; }
+.title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 60px; }
+.area-col { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 40px; }
+.action { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 60px; }
+.ci { white-space: nowrap; padding: 5px 4px; min-width: 24px; overflow: hidden; }
 .ci-warn { color: #d29922; font-size: 0.7em; vertical-align: super; margin-left: -2px; }
 .disc { text-align: right; white-space: nowrap; padding: 5px 3px; font-size: 0.8em; }
 .num { text-align: right; white-space: nowrap; padding: 5px 4px; }
-.author { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.author { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 40px; }
+.repo-col { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 25px; }
+
+/* Column chooser */
+.col-chooser-btn {
+  background: var(--header-bg); border: 1px solid var(--border); color: #8b949e; cursor: pointer;
+  padding: 3px 8px; border-radius: 4px; font-size: 0.8em; vertical-align: middle;
+}
+.col-chooser-btn:hover { color: var(--link); border-color: var(--link); }
+.col-chooser-popup {
+  position: fixed; background: #1c2128; border: 1px solid #444c56; border-radius: 6px;
+  padding: 8px 12px; font-size: 0.85em; color: #e6edf3; z-index: 100;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4); min-width: 150px;
+}
+.col-chooser-popup label {
+  display: block; padding: 3px 0; cursor: pointer; white-space: nowrap;
+  user-select: none;
+}
+.col-chooser-popup label:hover { color: var(--link); }
+.col-chooser-popup input[type="checkbox"] { margin-right: 6px; vertical-align: middle; }
 
 /* Heat classes */
 .heat-1 { background: rgba(187, 128, 9, 0.15); }
@@ -158,6 +177,7 @@ a.feedback:hover { background: #388bfd; color: #fff; text-decoration: none; }
   th.action-col { background: rgba(154, 103, 0, 0.1) !important; color: #9a6700; }
   a.feedback { background: #0969da; }
   a.feedback:hover { background: #0550ae; }
+  .col-chooser-popup { background: #fff; border-color: #d0d7de; color: #1f2328; box-shadow: 0 4px 12px rgba(0,0,0,0.12); }
   tr.your-turn { box-shadow: inset 3px 0 0 0 #bf8700; background: rgba(191, 135, 0, 0.06); }
   tr.your-turn:hover { background: rgba(191, 135, 0, 0.1); }
 }

--- a/docs/shared-styles.css
+++ b/docs/shared-styles.css
@@ -99,50 +99,57 @@ col[data-col="size"]   { width: 2.5%; }
 col[data-col="author"] { width: 8%; }
 col[data-col="area"]   { width: 7%; }
 
-/* Tier 1 (≤1200px): numbers vanish immediately, disc/age/upd/size shrink fast */
-@media (max-width: 1200px) {
+/* Tier 1 (≤1400px): ready/need/action vanish */
+@media (max-width: 1400px) {
   col[data-col="ready"]  { width: 0; }
   col[data-col="need"]   { width: 0; }
   col[data-col="action"] { width: 0; }
-  col[data-col="disc"]   { width: 1%; }
-  col[data-col="age"]    { width: 1%; }
-  col[data-col="upd"]    { width: 1%; }
-  col[data-col="size"]   { width: 1%; }
-  col[data-col="ci"]     { width: 2.5%; }
-  col[data-col="repo"]   { width: 5%; }
+  col[data-col="disc"]   { width: 2%; }
+  col[data-col="age"]    { width: 2%; }
+  col[data-col="upd"]    { width: 2%; }
+  col[data-col="size"]   { width: 2%; }
   col[data-col="author"] { width: 6%; }
-  col[data-col="area"]   { width: 5%; }
   td[data-col="ready"], th[data-col="ready"],
   td[data-col="need"], th[data-col="need"],
   td[data-col="action"], th[data-col="action"] { font-size: 0; padding: 0; border: 0; }
 }
 
-/* Tier 2 (≤900px): disc/age/upd/size vanish, CI to icon width, area/author squeeze */
-@media (max-width: 900px) {
+/* Tier 2 (≤1100px): disc/age/upd/size/author vanish */
+@media (max-width: 1100px) {
   col[data-col="disc"]   { width: 0; }
   col[data-col="age"]    { width: 0; }
   col[data-col="upd"]    { width: 0; }
   col[data-col="size"]   { width: 0; }
-  col[data-col="ci"]     { width: 1.5%; }
-  col[data-col="repo"]   { width: 4%; }
-  col[data-col="pr"]     { width: 3%; }
-  col[data-col="author"] { width: 4%; }
-  col[data-col="area"]   { width: 3%; }
+  col[data-col="author"] { width: 0; }
+  col[data-col="pr"]     { width: 4%; }
+  col[data-col="repo"]   { width: 7%; }
+  col[data-col="nextaction"] { width: 30%; }
+  col[data-col="ci"]     { width: 4%; }
+  col[data-col="area"]   { width: 6%; }
   td[data-col="disc"], th[data-col="disc"],
   td[data-col="age"], th[data-col="age"],
   td[data-col="upd"], th[data-col="upd"],
-  td[data-col="size"], th[data-col="size"] { font-size: 0; padding: 0; border: 0; }
+  td[data-col="size"], th[data-col="size"],
+  td[data-col="author"], th[data-col="author"] { font-size: 0; padding: 0; border: 0; }
 }
 
-/* Tier 3 (≤650px): area/author vanish, CI/repo/PR minimal, max space to title+nextaction */
-@media (max-width: 650px) {
-  col[data-col="ci"]     { width: 1%; }
-  col[data-col="repo"]   { width: 3%; }
-  col[data-col="pr"]     { width: 2.5%; }
-  col[data-col="author"] { width: 0; }
+/* Tier 3 (≤850px): area vanishes */
+@media (max-width: 850px) {
   col[data-col="area"]   { width: 0; }
-  td[data-col="author"], th[data-col="author"],
+  col[data-col="ci"]     { width: 3%; }
+  col[data-col="pr"]     { width: 5%; }
+  col[data-col="repo"]   { width: 8%; }
+  col[data-col="nextaction"] { width: 35%; }
   td[data-col="area"], th[data-col="area"] { font-size: 0; padding: 0; border: 0; }
+}
+
+/* Tier 4 (≤650px): CI vanishes, just PR/repo/title/nextaction */
+@media (max-width: 650px) {
+  col[data-col="ci"]     { width: 0; }
+  col[data-col="pr"]     { width: 5%; }
+  col[data-col="repo"]   { width: 8%; }
+  col[data-col="nextaction"] { width: 35%; }
+  td[data-col="ci"], th[data-col="ci"] { font-size: 0; padding: 0; border: 0; }
 }
 
 /* Column chooser */

--- a/docs/shared-styles.css
+++ b/docs/shared-styles.css
@@ -114,42 +114,25 @@ col[data-col="area"]   { width: 7%; }
   td[data-col="action"], th[data-col="action"] { font-size: 0; padding: 0; border: 0; }
 }
 
-/* Tier 2 (≤1100px): disc/age/upd/size/author vanish */
+/* Tier 2 (≤1100px): everything except PR/repo/title/nextaction vanishes */
 @media (max-width: 1100px) {
   col[data-col="disc"]   { width: 0; }
   col[data-col="age"]    { width: 0; }
   col[data-col="upd"]    { width: 0; }
   col[data-col="size"]   { width: 0; }
   col[data-col="author"] { width: 0; }
-  col[data-col="pr"]     { width: 4%; }
-  col[data-col="repo"]   { width: 7%; }
-  col[data-col="nextaction"] { width: 30%; }
-  col[data-col="ci"]     { width: 4%; }
-  col[data-col="area"]   { width: 6%; }
+  col[data-col="ci"]     { width: 0; }
+  col[data-col="area"]   { width: 0; }
+  col[data-col="pr"]     { width: 5%; }
+  col[data-col="repo"]   { width: 8%; }
+  col[data-col="nextaction"] { width: 35%; }
   td[data-col="disc"], th[data-col="disc"],
   td[data-col="age"], th[data-col="age"],
   td[data-col="upd"], th[data-col="upd"],
   td[data-col="size"], th[data-col="size"],
-  td[data-col="author"], th[data-col="author"] { font-size: 0; padding: 0; border: 0; }
-}
-
-/* Tier 3 (≤850px): area vanishes */
-@media (max-width: 850px) {
-  col[data-col="area"]   { width: 0; }
-  col[data-col="ci"]     { width: 3%; }
-  col[data-col="pr"]     { width: 5%; }
-  col[data-col="repo"]   { width: 8%; }
-  col[data-col="nextaction"] { width: 35%; }
+  td[data-col="author"], th[data-col="author"],
+  td[data-col="ci"], th[data-col="ci"],
   td[data-col="area"], th[data-col="area"] { font-size: 0; padding: 0; border: 0; }
-}
-
-/* Tier 4 (≤650px): CI vanishes, just PR/repo/title/nextaction */
-@media (max-width: 650px) {
-  col[data-col="ci"]     { width: 0; }
-  col[data-col="pr"]     { width: 5%; }
-  col[data-col="repo"]   { width: 8%; }
-  col[data-col="nextaction"] { width: 35%; }
-  td[data-col="ci"], th[data-col="ci"] { font-size: 0; padding: 0; border: 0; }
 }
 
 /* Column chooser */

--- a/docs/shared-styles.css
+++ b/docs/shared-styles.css
@@ -67,17 +67,92 @@ th.sortable { cursor: pointer; user-select: none; }
 th.sortable:hover { color: var(--link); }
 th.sorted { color: var(--link); }
 
-/* PR table cells */
-.pr-num { white-space: nowrap; min-width: 35px; }
-.title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 60px; }
-.area-col { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 40px; }
-.action { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 60px; }
-.ci { white-space: nowrap; padding: 5px 4px; min-width: 24px; overflow: hidden; }
+/* PR table cells -- min-widths use data-col so both th and td are covered */
+.pr-num { white-space: nowrap; }
+.title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.area-col { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.action { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ci { white-space: nowrap; padding: 5px 4px; overflow: hidden; }
 .ci-warn { color: #d29922; font-size: 0.7em; vertical-align: super; margin-left: -2px; }
 .disc { text-align: right; white-space: nowrap; padding: 5px 3px; font-size: 0.8em; }
 .num { text-align: right; white-space: nowrap; padding: 5px 4px; }
-.author { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 40px; }
-.repo-col { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 25px; }
+.author { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.repo-col { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* Non-proportional shrink tiers via data-col attribute selectors */
+/* All cells clip overflow in fixed layout */
+td[data-col], th[data-col] { overflow: hidden; text-overflow: ellipsis; }
+
+/* Default (wide) column widths — matches original inline percentages */
+col[data-col="ready"]  { width: 2.5%; }
+col[data-col="need"]   { width: 2.5%; }
+col[data-col="action"] { width: 2.5%; }
+col[data-col="pr"]     { width: 3.5%; }
+col[data-col="repo"]   { width: 6%; }
+/* title has no explicit width — it gets the remaining flex space */
+col[data-col="nextaction"] { width: 25%; }
+col[data-col="ci"]     { width: 6%; }
+col[data-col="disc"]   { width: 3%; }
+col[data-col="age"]    { width: 2.5%; }
+col[data-col="upd"]    { width: 2.5%; }
+col[data-col="size"]   { width: 2.5%; }
+col[data-col="author"] { width: 8%; }
+col[data-col="area"]   { width: 7%; }
+
+/* Medium-narrow: squeeze collapse-first columns, give space to content columns */
+@media (max-width: 1200px) {
+  col[data-col="ready"]  { width: 1.5%; }
+  col[data-col="need"]   { width: 1.5%; }
+  col[data-col="action"] { width: 2%; }
+  col[data-col="disc"]   { width: 1.5%; }
+  col[data-col="age"]    { width: 1.5%; }
+  col[data-col="upd"]    { width: 1.5%; }
+  col[data-col="size"]   { width: 1.5%; }
+  col[data-col="ci"]     { width: 3%; }
+  col[data-col="repo"]   { width: 4%; }
+  col[data-col="author"] { width: 5%; }
+  col[data-col="area"]   { width: 5%; }
+}
+
+/* Narrow: collapse-first columns nearly vanish */
+@media (max-width: 900px) {
+  col[data-col="ready"]  { width: 0.5%; }
+  col[data-col="need"]   { width: 0.5%; }
+  col[data-col="action"] { width: 1%; }
+  col[data-col="disc"]   { width: 0.5%; }
+  col[data-col="age"]    { width: 0.5%; }
+  col[data-col="upd"]    { width: 0.5%; }
+  col[data-col="size"]   { width: 1%; }
+  col[data-col="ci"]     { width: 2%; }
+  col[data-col="repo"]   { width: 2.5%; }
+  col[data-col="pr"]     { width: 2.5%; }
+  col[data-col="author"] { width: 4%; }
+  col[data-col="area"]   { width: 3%; }
+  col[data-col="nextaction"] { width: 20%; }
+}
+
+/* Very narrow: collapse-first columns hidden, minimal widths for remaining */
+@media (max-width: 650px) {
+  col[data-col="ready"]  { width: 0; }
+  col[data-col="need"]   { width: 0; }
+  col[data-col="disc"]   { width: 0; }
+  col[data-col="age"]    { width: 0; }
+  col[data-col="upd"]    { width: 0; }
+  col[data-col="action"] { width: 0.5%; }
+  col[data-col="size"]   { width: 0.5%; }
+  col[data-col="ci"]     { width: 1.5%; }
+  col[data-col="repo"]   { width: 2%; }
+  col[data-col="pr"]     { width: 2%; }
+  col[data-col="author"] { width: 3%; }
+  col[data-col="area"]   { width: 0; }
+  col[data-col="nextaction"] { width: 15%; }
+  td[data-col="ready"], th[data-col="ready"],
+  td[data-col="need"], th[data-col="need"],
+  td[data-col="disc"], th[data-col="disc"],
+  td[data-col="age"], th[data-col="age"],
+  td[data-col="upd"], th[data-col="upd"],
+  td[data-col="area"], th[data-col="area"] { font-size: 0; padding: 0; border: 0; }
+}
 
 /* Column chooser */
 .col-chooser-btn {
@@ -96,6 +171,12 @@ th.sorted { color: var(--link); }
 }
 .col-chooser-popup label:hover { color: var(--link); }
 .col-chooser-popup input[type="checkbox"] { margin-right: 6px; vertical-align: middle; }
+.col-chooser-reset {
+  display: block; margin-top: 6px; padding-top: 6px; border-top: 1px solid #444c56;
+  color: #8b949e; cursor: pointer; font-size: 0.85em; text-align: center;
+  background: none; border-left: none; border-right: none; border-bottom: none; width: 100%;
+}
+.col-chooser-reset:hover { color: var(--link); }
 
 /* Heat classes */
 .heat-1 { background: rgba(187, 128, 9, 0.15); }

--- a/docs/shared-ui.js
+++ b/docs/shared-ui.js
@@ -166,6 +166,7 @@
     table._unlockLayout = function() { locked = false; };
     ths.forEach(function(th) {
       var grip = document.createElement('div');
+      grip.className = 'col-resize-grip';
       grip.style.cssText = 'position:absolute;top:0;right:0;bottom:0;width:5px;cursor:col-resize;user-select:none;border-right:1px solid #484f58';
       th.style.position = 'relative';
       grip.addEventListener('mousedown', function(e) {
@@ -242,23 +243,29 @@
     // Apply on load
     applyHidden();
 
-    // Reuse existing button if already created (re-render safe)
+    // Reuse existing button if already created (re-render safe).
+    // Clone to drop old listeners that close over a detached table.
     var btnId = tableId + '-col-chooser-btn';
     var btn = document.getElementById(btnId);
-    if (btn) return; // already wired up
-    btn = document.createElement('button');
-    btn.type = 'button';
-    btn.id = btnId;
-    btn.className = 'col-chooser-btn';
-    btn.textContent = '\u2699 Columns';
-    btn.title = 'Show/hide table columns';
-
-    // Place in specified container or before the table
-    var container = containerId && document.getElementById(containerId);
-    if (container) {
-      container.appendChild(btn);
+    if (btn) {
+      var fresh = btn.cloneNode(true);
+      btn.parentNode.replaceChild(fresh, btn);
+      btn = fresh;
     } else {
-      table.parentNode.insertBefore(btn, table);
+      btn = document.createElement('button');
+      btn.type = 'button';
+      btn.id = btnId;
+      btn.className = 'col-chooser-btn';
+      btn.textContent = '\u2699 Columns';
+      btn.title = 'Show/hide table columns';
+
+      // Place in specified container or before the table
+      var container = containerId && document.getElementById(containerId);
+      if (container) {
+        container.appendChild(btn);
+      } else {
+        table.parentNode.insertBefore(btn, table);
+      }
     }
 
     var popup = null;
@@ -323,8 +330,11 @@
       var r = btn.getBoundingClientRect();
       popup.style.left = Math.max(0, Math.min(r.left, window.innerWidth - 180)) + 'px';
       popup.style.top = (r.bottom + 4) + 'px';
-      // Dismiss on outside click (single tracked listener)
+      // Dismiss on outside click (single tracked listener).
+      // Guard: only attach if popup is still open when the timeout fires.
+      var currentPopup = popup;
       setTimeout(function() {
+        if (popup !== currentPopup) return; // popup was closed before timeout fired
         dismissFn = function(ev) {
           if (popup && !popup.contains(ev.target) && ev.target !== btn) {
             closePopup();

--- a/docs/shared-ui.js
+++ b/docs/shared-ui.js
@@ -152,16 +152,18 @@
     var locked = false;
     function lockLayout() {
       if (locked) return; locked = true;
-      // Freeze current column widths then switch to fixed layout
+      // Freeze current column widths so drag-resize works in absolute px
       var widths = Array.prototype.map.call(ths, function(h) { return h.offsetWidth + 'px'; });
-      // Clear <col> widths so th widths drive fixed-layout sizing
+      // Override CSS-driven <col> widths with snapshotted px widths
       var cols = table.querySelectorAll('colgroup col');
-      cols.forEach(function(c) { c.style.width = ''; });
+      cols.forEach(function(c, i) { c.style.width = widths[i]; });
       ths.forEach(function(h, i) {
         h.style.width = widths[i]; h.style.minWidth = widths[i]; h.style.maxWidth = widths[i];
       });
       table.style.tableLayout = 'fixed';
     }
+    // Expose unlock so column chooser reset can undo drag-resize
+    table._unlockLayout = function() { locked = false; };
     ths.forEach(function(th) {
       var grip = document.createElement('div');
       grip.style.cssText = 'position:absolute;top:0;right:0;bottom:0;width:5px;cursor:col-resize;user-select:none';
@@ -180,18 +182,22 @@
   };
 
   // Column chooser: hide/show columns, persisted in localStorage
-  window.initColumnChooser = function(tableId, storageKey) {
+  window.initColumnChooser = function(tableId, storageKey, containerId) {
     var table = document.getElementById(tableId);
     if (!table) return;
     storageKey = storageKey || 'pr-dashboard-hidden-cols';
 
-    // Column definitions: data-col value -> display label
-    var allCols = [];
-    var ths = table.querySelectorAll('thead th[data-col]');
-    ths.forEach(function(th) {
-      allCols.push({ id: th.getAttribute('data-col'), label: th.textContent.trim() });
-    });
-    if (allCols.length === 0) return;
+
+    // Column definitions: data-col value -> display label (strip sort arrows)
+    function readCols() {
+      var cols = [];
+      table.querySelectorAll('thead th[data-col]').forEach(function(th) {
+        var label = th.textContent.replace(/[\u25B2\u25BC\u2191\u2193]/g, '').trim();
+        cols.push({ id: th.getAttribute('data-col'), label: label });
+      });
+      return cols;
+    }
+    if (readCols().length === 0) return;
 
     // Read hidden set from localStorage
     var hidden;
@@ -204,7 +210,6 @@
     function applyHidden() {
       var set = {};
       hidden.forEach(function(c) { set[c] = true; });
-      // Toggle display on col, th, and td with matching data-col
       table.querySelectorAll('[data-col]').forEach(function(el) {
         el.style.display = set[el.getAttribute('data-col')] ? 'none' : '';
       });
@@ -217,27 +222,47 @@
     // Apply on load
     applyHidden();
 
-    // Create ⚙ button — insert near the table
-    var btn = document.createElement('button');
+    // Reuse existing button if already created (re-render safe)
+    var btnId = tableId + '-col-chooser-btn';
+    var btn = document.getElementById(btnId);
+    if (btn) return; // already wired up
+    btn = document.createElement('button');
     btn.type = 'button';
+    btn.id = btnId;
     btn.className = 'col-chooser-btn';
     btn.textContent = '\u2699 Columns';
     btn.title = 'Show/hide table columns';
-    table.parentNode.insertBefore(btn, table);
+
+    // Place in specified container or before the table
+    var container = containerId && document.getElementById(containerId);
+    if (container) {
+      container.appendChild(btn);
+    } else {
+      table.parentNode.insertBefore(btn, table);
+    }
 
     var popup = null;
+    var dismissFn = null;
+
+    function closePopup() {
+      if (popup) { popup.remove(); popup = null; }
+      if (dismissFn) { document.removeEventListener('click', dismissFn); dismissFn = null; }
+    }
+
     btn.addEventListener('click', function(e) {
       e.stopPropagation();
-      if (popup) { popup.remove(); popup = null; return; }
+      if (popup) { closePopup(); return; }
       popup = document.createElement('div');
       popup.className = 'col-chooser-popup';
       var hiddenSet = {};
       hidden.forEach(function(c) { hiddenSet[c] = true; });
-      allCols.forEach(function(col) {
+      var checkboxes = [];
+      readCols().forEach(function(col) {
         var lbl = document.createElement('label');
         var cb = document.createElement('input');
         cb.type = 'checkbox';
         cb.checked = !hiddenSet[col.id];
+        cb.setAttribute('data-col-id', col.id);
         cb.addEventListener('change', function() {
           if (cb.checked) {
             hidden = hidden.filter(function(c) { return c !== col.id; });
@@ -250,21 +275,48 @@
         lbl.appendChild(cb);
         lbl.appendChild(document.createTextNode(col.label));
         popup.appendChild(lbl);
+        checkboxes.push(cb);
       });
+      // Reset button
+      var resetBtn = document.createElement('button');
+      resetBtn.type = 'button';
+      resetBtn.className = 'col-chooser-reset';
+      resetBtn.textContent = 'Reset all';
+      resetBtn.addEventListener('click', function() {
+        hidden = [];
+        saveHidden();
+        applyHidden();
+        checkboxes.forEach(function(cb) { cb.checked = true; });
+        // Clear any column width customizations from drag-resize
+        if (table._unlockLayout) table._unlockLayout();
+        table.querySelectorAll('thead th').forEach(function(th) {
+          th.style.width = ''; th.style.minWidth = ''; th.style.maxWidth = '';
+        });
+        // Clear inline <col> widths so CSS media-query rules take effect again
+        table.querySelectorAll('colgroup col').forEach(function(c) {
+          c.style.width = '';
+        });
+      });
+      popup.appendChild(resetBtn);
+
       document.body.appendChild(popup);
-      // Position below button
       var r = btn.getBoundingClientRect();
       popup.style.left = Math.max(0, Math.min(r.left, window.innerWidth - 180)) + 'px';
       popup.style.top = (r.bottom + 4) + 'px';
-      // Dismiss on outside click
+      // Dismiss on outside click (single tracked listener)
       setTimeout(function() {
-        document.addEventListener('click', function dismiss(ev) {
+        dismissFn = function(ev) {
           if (popup && !popup.contains(ev.target) && ev.target !== btn) {
-            popup.remove(); popup = null;
-            document.removeEventListener('click', dismiss);
+            closePopup();
           }
-        });
+        };
+        document.addEventListener('click', dismissFn);
       }, 0);
+    });
+
+    // Dismiss on Escape
+    document.addEventListener('keydown', function(ev) {
+      if (ev.key === 'Escape' && popup) closePopup();
     });
   };
 })();

--- a/docs/shared-ui.js
+++ b/docs/shared-ui.js
@@ -171,7 +171,13 @@
       grip.addEventListener('mousedown', function(e) {
         lockLayout();
         var startX = e.pageX, startW = th.offsetWidth;
-        function onMove(e2) { th.style.width = Math.max(30, startW + e2.pageX - startX) + 'px'; th.style.minWidth = th.style.width; th.style.maxWidth = th.style.width; }
+        var colKey = th.getAttribute('data-col');
+        var col = colKey ? table.querySelector('colgroup col[data-col="' + colKey + '"]') : null;
+        function onMove(e2) {
+          var w = Math.max(30, startW + e2.pageX - startX) + 'px';
+          th.style.width = w; th.style.minWidth = w; th.style.maxWidth = w;
+          if (col) col.style.width = w;
+        }
         function onUp() { document.removeEventListener('mousemove', onMove); document.removeEventListener('mouseup', onUp); }
         document.addEventListener('mousemove', onMove);
         document.addEventListener('mouseup', onUp);

--- a/docs/shared-ui.js
+++ b/docs/shared-ui.js
@@ -166,7 +166,7 @@
     table._unlockLayout = function() { locked = false; };
     ths.forEach(function(th) {
       var grip = document.createElement('div');
-      grip.style.cssText = 'position:absolute;top:0;right:0;bottom:0;width:5px;cursor:col-resize;user-select:none';
+      grip.style.cssText = 'position:absolute;top:0;right:0;bottom:0;width:5px;cursor:col-resize;user-select:none;border-right:1px solid #484f58';
       th.style.position = 'relative';
       grip.addEventListener('mousedown', function(e) {
         lockLayout();

--- a/docs/shared-ui.js
+++ b/docs/shared-ui.js
@@ -178,4 +178,93 @@
       th.appendChild(grip);
     });
   };
+
+  // Column chooser: hide/show columns, persisted in localStorage
+  window.initColumnChooser = function(tableId, storageKey) {
+    var table = document.getElementById(tableId);
+    if (!table) return;
+    storageKey = storageKey || 'pr-dashboard-hidden-cols';
+
+    // Column definitions: data-col value -> display label
+    var allCols = [];
+    var ths = table.querySelectorAll('thead th[data-col]');
+    ths.forEach(function(th) {
+      allCols.push({ id: th.getAttribute('data-col'), label: th.textContent.trim() });
+    });
+    if (allCols.length === 0) return;
+
+    // Read hidden set from localStorage
+    var hidden;
+    try {
+      var raw = localStorage.getItem(storageKey);
+      hidden = raw ? JSON.parse(raw) : [];
+      if (!Array.isArray(hidden)) hidden = [];
+    } catch(e) { hidden = []; }
+
+    function applyHidden() {
+      var set = {};
+      hidden.forEach(function(c) { set[c] = true; });
+      // Toggle display on col, th, and td with matching data-col
+      table.querySelectorAll('[data-col]').forEach(function(el) {
+        el.style.display = set[el.getAttribute('data-col')] ? 'none' : '';
+      });
+    }
+
+    function saveHidden() {
+      try { localStorage.setItem(storageKey, JSON.stringify(hidden)); } catch(e) {}
+    }
+
+    // Apply on load
+    applyHidden();
+
+    // Create ⚙ button — insert near the table
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'col-chooser-btn';
+    btn.textContent = '\u2699 Columns';
+    btn.title = 'Show/hide table columns';
+    table.parentNode.insertBefore(btn, table);
+
+    var popup = null;
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      if (popup) { popup.remove(); popup = null; return; }
+      popup = document.createElement('div');
+      popup.className = 'col-chooser-popup';
+      var hiddenSet = {};
+      hidden.forEach(function(c) { hiddenSet[c] = true; });
+      allCols.forEach(function(col) {
+        var lbl = document.createElement('label');
+        var cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.checked = !hiddenSet[col.id];
+        cb.addEventListener('change', function() {
+          if (cb.checked) {
+            hidden = hidden.filter(function(c) { return c !== col.id; });
+          } else {
+            if (hidden.indexOf(col.id) === -1) hidden.push(col.id);
+          }
+          saveHidden();
+          applyHidden();
+        });
+        lbl.appendChild(cb);
+        lbl.appendChild(document.createTextNode(col.label));
+        popup.appendChild(lbl);
+      });
+      document.body.appendChild(popup);
+      // Position below button
+      var r = btn.getBoundingClientRect();
+      popup.style.left = Math.max(0, Math.min(r.left, window.innerWidth - 180)) + 'px';
+      popup.style.top = (r.bottom + 4) + 'px';
+      // Dismiss on outside click
+      setTimeout(function() {
+        document.addEventListener('click', function dismiss(ev) {
+          if (popup && !popup.contains(ev.target) && ev.target !== btn) {
+            popup.remove(); popup = null;
+            document.removeEventListener('click', dismiss);
+          }
+        });
+      }, 0);
+    });
+  };
 })();

--- a/docs/shared-ui.js
+++ b/docs/shared-ui.js
@@ -210,8 +210,22 @@
     function applyHidden() {
       var set = {};
       hidden.forEach(function(c) { set[c] = true; });
-      table.querySelectorAll('[data-col]').forEach(function(el) {
-        el.style.display = set[el.getAttribute('data-col')] ? 'none' : '';
+      // For table-layout:fixed, we must zero out the <col> width AND hide cell content
+      table.querySelectorAll('colgroup col[data-col]').forEach(function(col) {
+        if (set[col.getAttribute('data-col')]) {
+          col.style.width = '0';
+        } else if (!col.style.width || col.style.width === '0' || col.style.width === '0px') {
+          col.style.width = ''; // restore CSS-driven width
+        }
+      });
+      table.querySelectorAll('td[data-col], th[data-col]').forEach(function(el) {
+        if (set[el.getAttribute('data-col')]) {
+          el.style.fontSize = '0'; el.style.padding = '0';
+          el.style.border = '0'; el.style.overflow = 'hidden';
+        } else {
+          el.style.fontSize = ''; el.style.padding = '';
+          el.style.border = ''; el.style.overflow = '';
+        }
       });
     }
 

--- a/tests/run-parallel.js
+++ b/tests/run-parallel.js
@@ -60,7 +60,7 @@ function runScript(script, extraEnv) {
   // Wall-clock bottleneck: ~120 s instead of the previous ~264 s sequential run.
   const results = await Promise.all([
     runScript('test-pr-filters.js'),
-    runScript('test-pr-extended.js', { ONLY_GROUPS: 'A,B,C,D,E,G,H,J,K,L' }),
+    runScript('test-pr-extended.js', { ONLY_GROUPS: 'A,B,C,D,E,G,H,J,K,L,M' }),
     runScript('test-pr-extended.js', { ONLY_GROUPS: 'F' }),
     runScript('test-pr-extended.js', { ONLY_GROUPS: 'I' }),
   ]);

--- a/tests/test-pr-extended.js
+++ b/tests/test-pr-extended.js
@@ -29,7 +29,9 @@ async function runTests() {
   // Shared context: reusing one context (vs. per-test newContext) avoids the overhead of
   // spinning up a new browser context (~100ms+) for every test. localStorage isolation is
   // achieved via addInitScript, which runs before any page script on every navigation.
-  const ctx = await browser.newContext();
+  // Use a wide viewport so all columns are visible (media queries hide columns at ≤1400px).
+  // Group M tests narrow viewports using separate browser contexts.
+  const ctx = await browser.newContext({ viewport: { width: 1600, height: 900 } });
   await ctx.addInitScript(() => { try { localStorage.clear(); } catch (e) {} });
 
   // Helper: open a fresh page and wait for the PR table to have rows.
@@ -383,7 +385,6 @@ async function runTests() {
     // D3: After sort, first row score ≥ last visible row score (numeric desc)
     {
       const p = await openPage(ALL, 100);
-      // Find a numeric sortable column
       const numHeader = await p.$('#pr-table thead th.sortable[data-sort="num"]');
       if (!numHeader) { fail('D3: Numeric sort order', 'no th[data-sort=num] found'); }
       else {
@@ -1378,6 +1379,180 @@ async function runTests() {
     }
 
     } // end GROUP L
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Group M: Column visibility at different viewport widths
+    // Validates the CSS media-query responsive column hiding and the column
+    // chooser UI. Tests use separate browser contexts with explicit viewports.
+    // ═══════════════════════════════════════════════════════════════════════════
+    if (shouldRun('M')) { log('\n── Group M: Responsive columns & chooser ──');
+
+    // Helper: true when a data-col column has computed width > 1px in the table
+    async function isColVisible(page, colId) {
+      return page.evaluate(id => {
+        const th = document.querySelector('th[data-col="' + id + '"]');
+        if (!th) return false;
+        const w = th.getBoundingClientRect().width;
+        return w > 1;
+      }, colId);
+    }
+
+    const coreCols = ['pr', 'repo', 'title', 'nextaction'];
+    const tier1Cols = ['ready', 'need', 'action']; // vanish at ≤1400px
+    const tier2Cols = ['ci', 'disc', 'age', 'upd', 'size', 'author', 'area']; // vanish at ≤1100px
+
+    // M1: Wide viewport (1600px) — all columns visible
+    {
+      // Reuse the existing wide context
+      const p = await openPage(ALL, 1);
+      const allCols = [...coreCols, ...tier1Cols, ...tier2Cols];
+      const visibility = {};
+      for (const col of allCols) visibility[col] = await isColVisible(p, col);
+      const allVisible = allCols.every(c => visibility[c]);
+      if (allVisible) pass('M1: All columns visible at 1600px');
+      else fail('M1: All columns visible at 1600px', 'hidden: ' + allCols.filter(c => !visibility[c]).join(', '));
+      await p.close();
+    }
+
+    // M2: Medium viewport (1300px ≤1400px) — tier1 columns hidden, others visible
+    {
+      const narrowCtx = await browser.newContext({ viewport: { width: 1300, height: 900 } });
+      await narrowCtx.addInitScript(() => { try { localStorage.clear(); } catch (e) {} });
+      const p = await narrowCtx.newPage();
+      await p.goto(ALL, { waitUntil: 'domcontentloaded' });
+      await p.waitForFunction(n => document.querySelectorAll('#pr-table tbody tr').length >= n, 1, { timeout: 20000 }).catch(() => null);
+      const tier1Hidden = [];
+      for (const col of tier1Cols) { if (await isColVisible(p, col)) tier1Hidden.push(col); }
+      const coreVis = [];
+      for (const col of coreCols) { if (!(await isColVisible(p, col))) coreVis.push(col); }
+      if (tier1Hidden.length === 0 && coreVis.length === 0) {
+        pass('M2: At 1300px — tier1 (ready/need/action) hidden, core cols visible');
+      } else {
+        fail('M2: At 1300px', 'tier1 still visible: ' + (tier1Hidden.join(',') || 'none') +
+          '; core hidden: ' + (coreVis.join(',') || 'none'));
+      }
+      await p.close();
+      await narrowCtx.close();
+    }
+
+    // M3: Narrow viewport (1000px ≤1100px) — only core 4 visible
+    {
+      const narrowCtx = await browser.newContext({ viewport: { width: 1000, height: 900 } });
+      await narrowCtx.addInitScript(() => { try { localStorage.clear(); } catch (e) {} });
+      const p = await narrowCtx.newPage();
+      await p.goto(ALL, { waitUntil: 'domcontentloaded' });
+      await p.waitForFunction(n => document.querySelectorAll('#pr-table tbody tr').length >= n, 1, { timeout: 20000 }).catch(() => null);
+      const nonCoreVisible = [];
+      for (const col of [...tier1Cols, ...tier2Cols]) {
+        if (await isColVisible(p, col)) nonCoreVisible.push(col);
+      }
+      const coreMissing = [];
+      for (const col of coreCols) { if (!(await isColVisible(p, col))) coreMissing.push(col); }
+      if (nonCoreVisible.length === 0 && coreMissing.length === 0) {
+        pass('M3: At 1000px — only core 4 columns visible');
+      } else {
+        fail('M3: At 1000px', 'non-core visible: ' + (nonCoreVisible.join(',') || 'none') +
+          '; core missing: ' + (coreMissing.join(',') || 'none'));
+      }
+      await p.close();
+      await narrowCtx.close();
+    }
+
+    // M4: Column chooser — toggle hides/shows column
+    {
+      const p = await openPage(ALL, 1);
+      const chooserBtn = await p.$('.col-chooser-btn');
+      if (!chooserBtn) {
+        fail('M4: Column chooser toggle', 'no .col-chooser-btn found');
+      } else {
+        await chooserBtn.click();
+        const popup = await p.waitForSelector('.col-chooser-popup', { timeout: 2000 }).catch(() => null);
+        if (!popup) {
+          fail('M4: Column chooser toggle', 'popup did not appear');
+        } else {
+          // Uncheck "author" column
+          const authorCb = await popup.$('input[data-col-id="author"]');
+          if (!authorCb) {
+            fail('M4: Column chooser toggle', 'no author checkbox');
+          } else {
+            await authorCb.click();
+            // Author column should now be hidden
+            const authorVis = await isColVisible(p, 'author');
+            if (!authorVis) pass('M4: Column chooser hides author column');
+            else fail('M4: Column chooser toggle', 'author still visible after unchecking');
+          }
+        }
+      }
+      await p.close();
+    }
+
+    // M5: Column chooser state persists in localStorage
+    {
+      // Use a separate context WITHOUT localStorage-clearing init script
+      const persistCtx = await browser.newContext({ viewport: { width: 1600, height: 900 } });
+      const p = await persistCtx.newPage();
+      await p.goto(ALL, { waitUntil: 'domcontentloaded' });
+      await p.waitForFunction(n => document.querySelectorAll('#pr-table tbody tr').length >= n, 1, { timeout: 20000 }).catch(() => null);
+      const chooserBtn = await p.$('.col-chooser-btn');
+      if (!chooserBtn) {
+        fail('M5: Column chooser persistence', 'no .col-chooser-btn found');
+      } else {
+        // Hide "area" column
+        await chooserBtn.click();
+        const popup = await p.waitForSelector('.col-chooser-popup', { timeout: 2000 }).catch(() => null);
+        const areaCb = popup && await popup.$('input[data-col-id="area"]');
+        if (!areaCb) {
+          fail('M5: Column chooser persistence', 'no area checkbox');
+        } else {
+          await areaCb.click();
+          await p.close();
+          // Open new page in same context — area should still be hidden (from localStorage)
+          const p2 = await persistCtx.newPage();
+          await p2.goto(ALL, { waitUntil: 'domcontentloaded' });
+          await p2.waitForFunction(n => document.querySelectorAll('#pr-table tbody tr').length >= n, 1, { timeout: 20000 }).catch(() => null);
+          const areaVis = await isColVisible(p2, 'area');
+          if (!areaVis) pass('M5: Column chooser state persists across page loads');
+          else fail('M5: Column chooser persistence', 'area visible after reload');
+          await p2.close();
+        }
+      }
+      await persistCtx.close();
+    }
+
+    // M6: Drag-resize updates column widths
+    {
+      const p = await openPage(ALL, 1);
+      // Wait for grips to be injected by initResizableColumns()
+      const grip = await p.waitForSelector('.col-resize-grip', { timeout: 5000 }).catch(() => null);
+      if (!grip) {
+        fail('M6: Drag-resize columns', 'no .col-resize-grip found');
+      } else {
+        const box = await grip.boundingBox();
+        if (!box) {
+          fail('M6: Drag-resize columns', 'grip not visible');
+        } else {
+          // Get initial width of the first th
+          const beforeW = await p.evaluate(() => {
+            const th = document.querySelector('#pr-table thead th');
+            return th ? th.getBoundingClientRect().width : 0;
+          });
+          // Drag grip 50px to the right
+          await p.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+          await p.mouse.down();
+          await p.mouse.move(box.x + box.width / 2 + 50, box.y + box.height / 2, { steps: 5 });
+          await p.mouse.up();
+          const afterW = await p.evaluate(() => {
+            const th = document.querySelector('#pr-table thead th');
+            return th ? th.getBoundingClientRect().width : 0;
+          });
+          if (Math.abs(afterW - beforeW) > 10) pass('M6: Drag-resize changes column width (' + Math.round(beforeW) + ' → ' + Math.round(afterW) + 'px)');
+          else fail('M6: Drag-resize columns', 'width unchanged: ' + Math.round(beforeW) + ' → ' + Math.round(afterW));
+        }
+      }
+      await p.close();
+    }
+
+    } // end GROUP M
 
     // ── Summary ──────────────────────────────────────────────────────────────
     console.log('\n=== RESULTS: ' + passed + ' passed, ' + failed + ' failed ===');

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -56,34 +56,14 @@ class TestMediaQueryShrinking:
             assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1399px"
         page.close()
 
-    def test_1100_stats_author_vanish(self, browser):
-        """Tier 2 (≤1100px): disc/age/upd/size/author vanish."""
+    def test_1100_only_core_remain(self, browser):
+        """Tier 2 (≤1100px): only PR/repo/title/nextaction remain."""
         page = browser.new_page(viewport={"width": 1099, "height": 600})
         page.goto(BASE); page.wait_for_timeout(300)
-        for col in ["ready", "need", "action", "disc", "age", "upd", "size", "author"]:
+        for col in ["ready", "need", "action", "disc", "age", "upd", "size", "author", "ci", "area"]:
             assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 1099px"
-        for col in ["pr", "repo", "title", "nextaction", "ci", "area"]:
-            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1099px"
-        page.close()
-
-    def test_850_area_vanishes(self, browser):
-        """Tier 3 (≤850px): area vanishes."""
-        page = browser.new_page(viewport={"width": 849, "height": 600})
-        page.goto(BASE); page.wait_for_timeout(300)
-        for col in ["ready", "need", "action", "disc", "age", "upd", "size", "author", "area"]:
-            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 849px"
-        for col in ["pr", "repo", "title", "nextaction", "ci"]:
-            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 849px"
-        page.close()
-
-    def test_650_ci_vanishes(self, browser):
-        """Tier 4 (≤650px): CI vanishes, only PR/repo/title/nextaction remain."""
-        page = browser.new_page(viewport={"width": 649, "height": 600})
-        page.goto(BASE); page.wait_for_timeout(300)
-        for col in ["ready", "need", "action", "disc", "age", "upd", "size", "author", "area", "ci"]:
-            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 649px"
         for col in ["pr", "repo", "title", "nextaction"]:
-            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 649px"
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1099px"
         page.close()
 
     def test_title_gets_more_space_as_narrower(self, browser):

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1,0 +1,249 @@
+"""
+Playwright tests for column picker and responsive column width behavior.
+Run with: python -m pytest tests/test_columns.py -v
+"""
+import pytest
+from playwright.sync_api import sync_playwright, expect
+
+BASE = "http://localhost:8080/_test_shrink.html"
+
+@pytest.fixture(scope="module")
+def browser():
+    with sync_playwright() as p:
+        b = p.chromium.launch()
+        yield b
+        b.close()
+
+@pytest.fixture
+def wide_page(browser):
+    """Full-width page where all columns are visible."""
+    page = browser.new_page(viewport={"width": 1400, "height": 600})
+    page.goto(BASE)
+    page.wait_for_timeout(300)
+    yield page
+    page.close()
+
+
+# ── Responsive media query tests ──
+
+class TestMediaQueryShrinking:
+
+    def _visible_width(self, page, col_id):
+        """Return the rendered pixel width of a column header."""
+        th = page.locator(f'th[data-col="{col_id}"]')
+        return th.bounding_box()["width"]
+
+    def _is_effectively_hidden(self, page, col_id):
+        """Column is hidden if its width is ≤ 2px (zero-width with rounding)."""
+        return self._visible_width(page, col_id) <= 2
+
+    def test_wide_all_visible(self, browser):
+        page = browser.new_page(viewport={"width": 1400, "height": 600})
+        page.goto(BASE); page.wait_for_timeout(300)
+        for col in ["ready", "need", "action", "pr", "repo", "title",
+                     "nextaction", "ci", "disc", "age", "upd", "size",
+                     "author", "area"]:
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1400px"
+        page.close()
+
+    def test_1200_numbers_vanish(self, browser):
+        page = browser.new_page(viewport={"width": 1199, "height": 600})
+        page.goto(BASE); page.wait_for_timeout(300)
+        for col in ["ready", "need", "action"]:
+            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 1199px"
+        # Important columns still visible
+        for col in ["pr", "repo", "title", "nextaction"]:
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1199px"
+        page.close()
+
+    def test_900_disc_age_upd_size_vanish(self, browser):
+        page = browser.new_page(viewport={"width": 899, "height": 600})
+        page.goto(BASE); page.wait_for_timeout(300)
+        for col in ["ready", "need", "action", "disc", "age", "upd", "size"]:
+            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 899px"
+        for col in ["pr", "repo", "title", "nextaction", "ci"]:
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 899px"
+        page.close()
+
+    def test_650_author_area_vanish(self, browser):
+        page = browser.new_page(viewport={"width": 649, "height": 600})
+        page.goto(BASE); page.wait_for_timeout(300)
+        for col in ["ready", "need", "action", "disc", "age", "upd", "size", "author", "area"]:
+            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 649px"
+        for col in ["pr", "repo", "title", "nextaction"]:
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 649px"
+        page.close()
+
+    def test_title_gets_more_space_as_narrower(self, browser):
+        """Title column should get a larger share of total width as viewport narrows."""
+        widths = {}
+        for vw in [1400, 899]:
+            page = browser.new_page(viewport={"width": vw, "height": 600})
+            page.goto(BASE); page.wait_for_timeout(300)
+            tw = page.locator("#pr-table").bounding_box()["width"]
+            title_w = self._visible_width(page, "title")
+            widths[vw] = title_w / tw
+            page.close()
+        assert widths[899] > widths[1400], \
+            f"Title share should grow: {widths[1400]:.2%} at 1400 vs {widths[899]:.2%} at 899"
+
+
+# ── Column picker tests ──
+
+# We need a page that has the column chooser initialized.
+# The _test_shrink.html doesn't have shared-ui.js, so we create a richer fixture.
+
+PICKER_HTML = """<!DOCTYPE html>
+<html><head>
+<link rel="stylesheet" href="shared-styles.css">
+<style>table#pr-table { table-layout: fixed; }</style>
+</head><body>
+<div id="controls"></div>
+<table id="pr-table">
+<colgroup>
+  <col data-col="ready"><col data-col="need"><col data-col="action">
+  <col data-col="pr"><col data-col="repo">
+  <col data-col="title"><col data-col="nextaction">
+  <col data-col="ci"><col data-col="disc">
+  <col data-col="age"><col data-col="upd"><col data-col="size">
+  <col data-col="author"><col data-col="area">
+</colgroup>
+<thead><tr>
+  <th data-col="ready">Rdy</th><th data-col="need">Need</th><th data-col="action">Act</th>
+  <th data-col="pr">PR</th><th data-col="repo">Repo</th>
+  <th data-col="title">Title</th><th data-col="nextaction">Next Action</th>
+  <th data-col="ci">CI</th><th data-col="disc">Disc</th>
+  <th data-col="age">Age</th><th data-col="upd">Upd</th><th data-col="size">Size</th>
+  <th data-col="author">Author</th><th data-col="area">Area</th>
+</tr></thead>
+<tbody>
+<tr>
+  <td data-col="ready">3</td><td data-col="need">1</td><td data-col="action">2</td>
+  <td data-col="pr">#4821</td><td data-col="repo">runtime</td>
+  <td data-col="title">Fix regex perf</td>
+  <td data-col="nextaction">Waiting on CI</td>
+  <td data-col="ci">ok</td><td data-col="disc">5</td>
+  <td data-col="age">3d</td><td data-col="upd">1h</td><td data-col="size">M</td>
+  <td data-col="author">dan</td><td data-col="area">regex</td>
+</tr>
+</tbody>
+</table>
+<script src="shared-ui.js"></script>
+<script>
+  initColumnChooser('pr-table', 'test-hidden-cols', 'controls');
+</script>
+</body></html>"""
+
+
+@pytest.fixture
+def picker_page(browser):
+    """Page with column chooser initialized, at wide viewport."""
+    import pathlib, tempfile
+    # Write the picker test page
+    path = pathlib.Path(r"C:\git\pr-dashboard\docs\_test_picker.html")
+    path.write_text(PICKER_HTML, encoding="utf-8")
+    page = browser.new_page(viewport={"width": 1400, "height": 600})
+    # Clear localStorage for clean state
+    page.goto("http://localhost:8080/_test_picker.html")
+    page.evaluate("localStorage.removeItem('test-hidden-cols')")
+    page.reload()
+    page.wait_for_timeout(300)
+    yield page
+    page.close()
+    path.unlink(missing_ok=True)
+
+
+class TestColumnPicker:
+
+    def _col_width(self, page, col_id):
+        th = page.locator(f'th[data-col="{col_id}"]')
+        return th.bounding_box()["width"]
+
+    def _open_picker(self, page):
+        page.locator(".col-chooser-btn").click()
+        page.wait_for_timeout(200)
+
+    def _checkbox_for(self, page, col_id):
+        return page.locator(f'.col-chooser-popup input[data-col-id="{col_id}"]')
+
+    def test_picker_button_exists(self, picker_page):
+        assert picker_page.locator(".col-chooser-btn").is_visible()
+
+    def test_picker_opens_and_closes(self, picker_page):
+        self._open_picker(picker_page)
+        assert picker_page.locator(".col-chooser-popup").is_visible()
+        # Click button again to close
+        picker_page.locator(".col-chooser-btn").click()
+        picker_page.wait_for_timeout(200)
+        assert picker_page.locator(".col-chooser-popup").count() == 0
+
+    def test_uncheck_hides_column(self, picker_page):
+        """Unchecking a column in the picker should make it effectively zero-width."""
+        # Verify repo is visible first
+        assert self._col_width(picker_page, "repo") > 10
+        # Open picker and uncheck repo
+        self._open_picker(picker_page)
+        cb = self._checkbox_for(picker_page, "repo")
+        cb.uncheck()
+        picker_page.wait_for_timeout(200)
+        # Repo column should now be effectively hidden
+        assert self._col_width(picker_page, "repo") <= 2, "repo should be hidden after unchecking"
+
+    def test_recheck_restores_column(self, picker_page):
+        """Checking a previously unchecked column restores it."""
+        orig_w = self._col_width(picker_page, "author")
+        # Hide author
+        self._open_picker(picker_page)
+        self._checkbox_for(picker_page, "author").uncheck()
+        picker_page.wait_for_timeout(200)
+        assert self._col_width(picker_page, "author") <= 2
+        # Show author again
+        self._checkbox_for(picker_page, "author").check()
+        picker_page.wait_for_timeout(200)
+        restored_w = self._col_width(picker_page, "author")
+        assert restored_w > 10, f"author should be restored, got {restored_w}px"
+
+    def test_hidden_persists_across_reload(self, picker_page):
+        """Hidden columns should persist in localStorage across page reload."""
+        self._open_picker(picker_page)
+        self._checkbox_for(picker_page, "disc").uncheck()
+        picker_page.wait_for_timeout(200)
+        assert self._col_width(picker_page, "disc") <= 2
+        # Reload
+        picker_page.reload()
+        picker_page.wait_for_timeout(500)
+        assert self._col_width(picker_page, "disc") <= 2, "disc should stay hidden after reload"
+
+    def test_reset_shows_all_columns(self, picker_page):
+        """Reset button should show all columns."""
+        # Hide a couple columns
+        self._open_picker(picker_page)
+        self._checkbox_for(picker_page, "age").uncheck()
+        self._checkbox_for(picker_page, "size").uncheck()
+        picker_page.wait_for_timeout(200)
+        assert self._col_width(picker_page, "age") <= 2
+        assert self._col_width(picker_page, "size") <= 2
+        # Click Reset
+        picker_page.locator(".col-chooser-reset").click()
+        picker_page.wait_for_timeout(200)
+        assert self._col_width(picker_page, "age") > 5, "age should be visible after reset"
+        assert self._col_width(picker_page, "size") > 5, "size should be visible after reset"
+
+    def test_escape_closes_picker(self, picker_page):
+        self._open_picker(picker_page)
+        assert picker_page.locator(".col-chooser-popup").is_visible()
+        picker_page.keyboard.press("Escape")
+        picker_page.wait_for_timeout(200)
+        assert picker_page.locator(".col-chooser-popup").count() == 0
+
+    def test_multiple_columns_hidden(self, picker_page):
+        """Can hide multiple columns simultaneously."""
+        self._open_picker(picker_page)
+        for col in ["ready", "need", "action", "disc"]:
+            self._checkbox_for(picker_page, col).uncheck()
+        picker_page.wait_for_timeout(200)
+        for col in ["ready", "need", "action", "disc"]:
+            assert self._col_width(picker_page, col) <= 2, f"{col} should be hidden"
+        # Important columns still have width
+        for col in ["title", "nextaction", "pr"]:
+            assert self._col_width(picker_page, col) > 20, f"{col} should still be visible"

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1,6 +1,8 @@
 """
 Playwright tests for column picker and responsive column width behavior.
-Run with: python -m pytest tests/test_columns.py -v
+These are manual-only Python Playwright checks; CI runs the Node Playwright suite
+(see test-pr-extended.js Group M for the CI-enforced column/viewport tests).
+Run locally with: python -m pytest tests/test_columns.py -v
 """
 import pytest
 from playwright.sync_api import sync_playwright, expect

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -122,6 +122,7 @@ PICKER_HTML = """<!DOCTYPE html>
 </table>
 <script src="shared-ui.js"></script>
 <script>
+  initResizableColumns('pr-table');
   initColumnChooser('pr-table', 'test-hidden-cols', 'controls');
 </script>
 </body></html>"""
@@ -239,3 +240,45 @@ class TestColumnPicker:
         # Important columns still have width
         for col in ["title", "nextaction", "pr"]:
             assert self._col_width(picker_page, col) > 20, f"{col} should still be visible"
+
+
+# ── Drag-to-resize tests ──
+
+class TestDragResize:
+
+    def _col_width(self, page, col_id):
+        th = page.locator(f'th[data-col="{col_id}"]')
+        return th.bounding_box()["width"]
+
+    def test_drag_resize_changes_column_width(self, picker_page):
+        """Dragging the right edge of a header should change its width."""
+        col = "repo"
+        before = self._col_width(picker_page, col)
+        th = picker_page.locator(f'th[data-col="{col}"]')
+        box = th.bounding_box()
+        # Drag from right edge of header 80px to the right
+        start_x = box["x"] + box["width"] - 2
+        start_y = box["y"] + box["height"] / 2
+        picker_page.mouse.move(start_x, start_y)
+        picker_page.mouse.down()
+        picker_page.mouse.move(start_x + 80, start_y, steps=5)
+        picker_page.mouse.up()
+        picker_page.wait_for_timeout(200)
+        after = self._col_width(picker_page, col)
+        assert after > before + 40, f"repo should have grown: {before:.0f} -> {after:.0f}"
+
+    def test_drag_resize_shrinks_column(self, picker_page):
+        """Dragging left should shrink a column."""
+        col = "nextaction"
+        before = self._col_width(picker_page, col)
+        th = picker_page.locator(f'th[data-col="{col}"]')
+        box = th.bounding_box()
+        start_x = box["x"] + box["width"] - 2
+        start_y = box["y"] + box["height"] / 2
+        picker_page.mouse.move(start_x, start_y)
+        picker_page.mouse.down()
+        picker_page.mouse.move(start_x - 80, start_y, steps=5)
+        picker_page.mouse.up()
+        picker_page.wait_for_timeout(200)
+        after = self._col_width(picker_page, col)
+        assert after < before - 40, f"nextaction should have shrunk: {before:.0f} -> {after:.0f}"

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -38,37 +38,49 @@ class TestMediaQueryShrinking:
         return self._visible_width(page, col_id) <= 2
 
     def test_wide_all_visible(self, browser):
-        page = browser.new_page(viewport={"width": 1400, "height": 600})
+        page = browser.new_page(viewport={"width": 1500, "height": 600})
         page.goto(BASE); page.wait_for_timeout(300)
         for col in ["ready", "need", "action", "pr", "repo", "title",
                      "nextaction", "ci", "disc", "age", "upd", "size",
                      "author", "area"]:
-            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1400px"
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1500px"
         page.close()
 
-    def test_1200_numbers_vanish(self, browser):
-        page = browser.new_page(viewport={"width": 1199, "height": 600})
+    def test_1400_numbers_vanish(self, browser):
+        """Tier 1 (≤1400px): ready/need/action vanish."""
+        page = browser.new_page(viewport={"width": 1399, "height": 600})
         page.goto(BASE); page.wait_for_timeout(300)
         for col in ["ready", "need", "action"]:
-            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 1199px"
-        # Important columns still visible
-        for col in ["pr", "repo", "title", "nextaction"]:
-            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1199px"
+            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 1399px"
+        for col in ["pr", "repo", "title", "nextaction", "ci", "author", "area"]:
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1399px"
         page.close()
 
-    def test_900_disc_age_upd_size_vanish(self, browser):
-        page = browser.new_page(viewport={"width": 899, "height": 600})
+    def test_1100_stats_author_vanish(self, browser):
+        """Tier 2 (≤1100px): disc/age/upd/size/author vanish."""
+        page = browser.new_page(viewport={"width": 1099, "height": 600})
         page.goto(BASE); page.wait_for_timeout(300)
-        for col in ["ready", "need", "action", "disc", "age", "upd", "size"]:
-            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 899px"
-        for col in ["pr", "repo", "title", "nextaction", "ci"]:
-            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 899px"
+        for col in ["ready", "need", "action", "disc", "age", "upd", "size", "author"]:
+            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 1099px"
+        for col in ["pr", "repo", "title", "nextaction", "ci", "area"]:
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 1099px"
         page.close()
 
-    def test_650_author_area_vanish(self, browser):
-        page = browser.new_page(viewport={"width": 649, "height": 600})
+    def test_850_area_vanishes(self, browser):
+        """Tier 3 (≤850px): area vanishes."""
+        page = browser.new_page(viewport={"width": 849, "height": 600})
         page.goto(BASE); page.wait_for_timeout(300)
         for col in ["ready", "need", "action", "disc", "age", "upd", "size", "author", "area"]:
+            assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 849px"
+        for col in ["pr", "repo", "title", "nextaction", "ci"]:
+            assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 849px"
+        page.close()
+
+    def test_650_ci_vanishes(self, browser):
+        """Tier 4 (≤650px): CI vanishes, only PR/repo/title/nextaction remain."""
+        page = browser.new_page(viewport={"width": 649, "height": 600})
+        page.goto(BASE); page.wait_for_timeout(300)
+        for col in ["ready", "need", "action", "disc", "age", "upd", "size", "author", "area", "ci"]:
             assert self._is_effectively_hidden(page, col), f"{col} should be hidden at 649px"
         for col in ["pr", "repo", "title", "nextaction"]:
             assert not self._is_effectively_hidden(page, col), f"{col} should be visible at 649px"
@@ -77,15 +89,15 @@ class TestMediaQueryShrinking:
     def test_title_gets_more_space_as_narrower(self, browser):
         """Title column should get a larger share of total width as viewport narrows."""
         widths = {}
-        for vw in [1400, 899]:
+        for vw in [1500, 1099]:
             page = browser.new_page(viewport={"width": vw, "height": 600})
             page.goto(BASE); page.wait_for_timeout(300)
             tw = page.locator("#pr-table").bounding_box()["width"]
             title_w = self._visible_width(page, "title")
             widths[vw] = title_w / tw
             page.close()
-        assert widths[899] > widths[1400], \
-            f"Title share should grow: {widths[1400]:.2%} at 1400 vs {widths[899]:.2%} at 899"
+        assert widths[1099] > widths[1500], \
+            f"Title share should grow: {widths[1500]:.2%} at 1500 vs {widths[1099]:.2%} at 1099"
 
 
 # ── Column picker tests ──


### PR DESCRIPTION
Closes #81

## Narrow display improvements

Two complementary features to make the dashboard usable on narrower displays without compromising the wide layout:

### Non-proportional column shrinking (CSS media queries)

Instead of all columns shrinking proportionally (making everything unreadable), columns now vanish in priority order as the viewport narrows:

| Width | Columns shown |
|---|---|
| >1400px | All 14 columns |
| ≤1400px | Ready/Need/Action vanish; stats shrink |
| ≤1100px | Only **PR, repo, title, next action** remain |

Columns fully vanish (width:0 + font-size:0) rather than shrinking to useless slivers.

### Column chooser

A ⚙ button lets users hide/show individual columns, persisted in localStorage. Includes a Reset option that restores all columns and clears any drag-resize customizations.

### Drag-to-resize fix

Fixed drag-to-resize which was broken — the drag handler was only updating `<th>` styles but with `table-layout: fixed` the width is controlled by `<col>` elements. Now updates both. Added visible gray grip lines in the header row.

### Tests

14 Playwright tests covering media query breakpoints, column picker behavior, and drag-to-resize. 
